### PR TITLE
Assuming defaut datetime

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -12,22 +12,9 @@ install:
   - docker build -t quantumleap .
 
 script:
-  # Move these to 3 reusable scripts
-  # Client
-  - docker-compose -f client/tests/docker-compose.yml up -d
-  - sleep 5
-  - docker run -ti --rm --network tests_clienttests quantumleap /bin/sh -c "pytest client/tests"
-  - docker-compose -f client/tests/docker-compose.yml down
-  # Translators
-  - docker-compose -f translators/tests/docker-compose.yml up -d
-  - sleep 8
-  - docker run -ti --rm --network tests_translatorstests quantumleap /bin/sh -c "pytest translators/tests"
-  - docker-compose -f translators/tests/docker-compose.yml down
-  # Reporter
-  - docker-compose -f reporter/tests/docker-compose.yml up -d
-  - sleep 8
-  - docker run -ti --rm --network tests_reportertests quantumleap /bin/sh -c "pytest reporter/tests"
-  - docker-compose -f reporter/tests/docker-compose.yml down
+  - cd client/tests && sh run_tests.sh && cd -
+  - cd translators/tests && sh run_tests.sh && cd -
+  - cd reporter/tests && sh run_tests.sh && cd -
 
 notifications:
   email: false

--- a/.travis.yml
+++ b/.travis.yml
@@ -12,6 +12,7 @@ install:
   - docker build -t quantumleap .
 
 script:
+  # Move these to 3 reusable scripts
   # Client
   - docker-compose -f client/tests/docker-compose.yml up -d
   - sleep 5
@@ -27,3 +28,6 @@ script:
   - sleep 8
   - docker run -ti --rm --network tests_reportertests quantumleap /bin/sh -c "pytest reporter/tests"
   - docker-compose -f reporter/tests/docker-compose.yml down
+
+notifications:
+  email: false

--- a/client/fixtures.py
+++ b/client/fixtures.py
@@ -10,12 +10,16 @@ ORION_HOST = os.environ.get('ORION_HOST', 'orion')
 ORION_PORT = os.environ.get('ORION_PORT', 1026)
 
 
-@pytest.fixture
-def fresh_db():
-    yield
+def do_clean_mongo():
     db_client = pm.MongoClient(MONGO_HOST, MONGO_PORT)
     db_client.drop_database("orion")
     db_client.drop_database("orion-default")
+
+
+@pytest.fixture
+def clean_mongo():
+    yield
+    do_clean_mongo()
 
 
 @pytest.fixture

--- a/client/tests/run_tests.sh
+++ b/client/tests/run_tests.sh
@@ -1,0 +1,6 @@
+#!/usr/bin/env bash
+
+docker-compose up -d
+sleep 5
+docker run -ti --rm --network tests_clienttests quantumleap /bin/sh -c "pytest client/tests"
+docker-compose down

--- a/client/tests/test_orion_handler.py
+++ b/client/tests/test_orion_handler.py
@@ -1,4 +1,4 @@
-from client.fixtures import orion_client as orion, fresh_db, entity
+from client.fixtures import orion_client as orion, clean_mongo, entity
 from random import random
 from utils.common import create_simple_subscription, create_simple_subscription_v1
 import json
@@ -11,7 +11,7 @@ def test_version(orion):
     assert '"version" : "1.7.0"' in r.text
 
 
-def test_subscribe(orion, fresh_db):
+def test_subscribe(orion, clean_mongo):
     notify_url = "http://somewhere/notify"
     subscription = create_simple_subscription(notify_url)
 
@@ -27,7 +27,7 @@ def test_subscribe(orion, fresh_db):
     assert len(subs) == 1
 
 
-def test_subscribe_v1(orion, fresh_db):
+def test_subscribe_v1(orion, clean_mongo):
     notify_url = "http://somewhere/notify"
     subscription = create_simple_subscription_v1(notify_url)
     r = orion.subscribe_v1(subscription)
@@ -42,12 +42,12 @@ def test_subscribe_v1(orion, fresh_db):
     assert len(subs) == 1
 
 
-def test_insert(orion, fresh_db, entity):
+def test_insert(orion, clean_mongo, entity):
     r = orion.insert(entity)
     assert r.ok, r.text
 
 
-def test_get(orion, fresh_db, entity):
+def test_get(orion, clean_mongo, entity):
     r = orion.insert(entity)
     assert r.ok
 
@@ -58,7 +58,7 @@ def test_get(orion, fresh_db, entity):
     assert loaded_entities[0] == entity
 
 
-def test_update(orion, fresh_db, entity):
+def test_update(orion, clean_mongo, entity):
     r = orion.insert(entity)
     assert r.ok
 
@@ -78,7 +78,7 @@ def test_update(orion, fresh_db, entity):
     assert loaded_v == pytest.approx(v)
 
 
-def test_delete(orion, fresh_db, entity):
+def test_delete(orion, clean_mongo, entity):
     r = orion.insert(entity)
     assert r.ok
 

--- a/conftest.py
+++ b/conftest.py
@@ -1,0 +1,24 @@
+from translators.crate import CrateTranslator
+import os
+import pytest
+
+QL_HOST = os.environ.get('QL_URL', "quantumleap")
+QL_PORT = 8668
+QL_URL = "http://{}:{}".format(QL_HOST, QL_PORT)
+
+CRATE_HOST = os.environ.get('CRATE_HOST', 'crate')
+CRATE_PORT = 4200
+
+
+def do_clean_crate():
+    from crate import client
+    conn = client.connect(["{}:{}".format(CRATE_HOST, CRATE_PORT)], error_trace=True)
+    cursor = conn.cursor()
+    # For now, we're working with only one table.
+    cursor.execute("DROP TABLE IF EXISTS {}".format(CrateTranslator.TABLE_NAME))
+
+
+@pytest.fixture()
+def clean_crate():
+    yield
+    do_clean_crate()

--- a/experiments/grafana/docker-compose.yml
+++ b/experiments/grafana/docker-compose.yml
@@ -31,7 +31,7 @@ services:
       - cratedb
 
   cratedb:
-    image: crate
+    image: crate:1.0.5
     ports:
       # Admin UI
       - "4200:4200"

--- a/experiments/grafana/ql_feeder.py
+++ b/experiments/grafana/ql_feeder.py
@@ -3,12 +3,13 @@ Simple script to experiment with QuantumLeap (QL).
 
 It will make the proper subscription in Orion and then create/update entities to generate the notifications for QL.
 """
-import json
-
 from client.client import OrionClient
+from client.fixtures import do_clean_mongo
+from conftest import do_clean_crate
 from experiments.comet.crazy_sensor import create_entity, update_args, sense
 from translators.crate import CrateTranslator
 from utils.hosts import LOCAL
+import json
 
 SLEEP = 5
 
@@ -26,9 +27,9 @@ def subscribe(orion, subscription):
 
 
 def get_subscription():
+    from conftest import QL_URL
     entity_id = '.*'
-    notify_url = 'http://quantumleap:8668/notify'
-    # notify_url = 'http://192.0.0.1:8668/notify'
+    notify_url = '{}/notify'.format(QL_URL)
     subscription = {
         "description": "Test subscription",
         "subject": {
@@ -66,12 +67,13 @@ if __name__ == '__main__':
     subscription_id = subscribe(orion, subscription)
     try:
         sense(orion, entity, update_args, SLEEP)
+        pass
     finally:
         r = orion.unsubscribe(subscription_id)
         assert r.ok, r.text
 
-        # Cleanup CrateDB
-        client = CrateTranslator(LOCAL)
-        client.setup()
-        client.dispose(testing=True)
+        # Cleanup Orion
+        do_clean_mongo()
 
+        # Cleanup CrateDB
+        do_clean_crate()

--- a/reporter/tests/docker-compose.yml
+++ b/reporter/tests/docker-compose.yml
@@ -31,6 +31,7 @@ services:
       - "8668:8668"
     depends_on:
       - orion
+      - crate
     networks:
         - reportertests
 

--- a/reporter/tests/run_tests.sh
+++ b/reporter/tests/run_tests.sh
@@ -1,0 +1,6 @@
+#!/bin/sh
+
+docker-compose up -d
+sleep 8
+docker run -ti --rm --network tests_reportertests quantumleap /bin/sh -c "pytest reporter/tests"
+docker-compose down

--- a/reporter/tests/run_tests.sh
+++ b/reporter/tests/run_tests.sh
@@ -1,4 +1,4 @@
-#!/bin/sh
+#!/usr/bin/env bash
 
 docker-compose up -d
 sleep 8

--- a/reporter/tests/test_reporter.py
+++ b/reporter/tests/test_reporter.py
@@ -1,5 +1,6 @@
 from client.client import HEADERS, HEADERS_PUT
-from client.fixtures import entity, fresh_db, orion_client
+from client.fixtures import entity, clean_mongo, orion_client
+from conftest import QL_URL
 from flask import url_for
 from translators.crate import CrateTranslator
 from translators.fixtures import crate_translator
@@ -7,12 +8,10 @@ from unittest.mock import patch
 from utils.common import assert_ngsi_entity_equals
 from utils.hosts import LOCAL
 import json
-import os
 import pytest
 import requests
 
 
-QL_URL = "http://{}:8668".format(os.environ.get('QL_URL', "quantumleap"))
 notify_url = "{}/notify".format(QL_URL)
 version_url = "{}/version".format(QL_URL)
 
@@ -79,7 +78,7 @@ def test_valid_notification(MockTranslator, live_server, notification):
     assert r.text == 'Notification successfully processed'
 
 
-def test_valid_no_modified(notification, crate_translator):
+def test_valid_no_modified(notification, clean_crate):
     notification['data'][0]['temperature']['metadata'].pop('dateModified')
     r = requests.post('{}'.format(notify_url), data=json.dumps(notification), headers=HEADERS_PUT)
     assert r.status_code == 200
@@ -133,7 +132,7 @@ def do_integration(entity, notify_url, orion_client, crate_translator):
     assert_ngsi_entity_equals(entities[0], entity)
 
 
-def test_integration(entity, orion_client, fresh_db, crate_translator):
+def test_integration(entity, orion_client, clean_mongo, crate_translator):
     """
     Test Reporter using input directly from an Orion notification and output directly to Cratedb.
     """

--- a/reporter/tests/test_reporter.py
+++ b/reporter/tests/test_reporter.py
@@ -61,19 +61,11 @@ def test_invalid_no_attr(notification):
     assert r.text == 'Received notification without attributes other than "type" and "id"'
 
 
-def test_invalid_no_modified(notification):
-    notification['data'][0]['temperature']['metadata'].pop('dateModified')
-    r = requests.post('{}'.format(notify_url), data=json.dumps(notification), headers=HEADERS_PUT)
-    assert r.status_code == 400
-    assert r.text == 'Modified attributes must come with dateModified metadata. ' \
-                     'Include "metadata": [ "dateModified" ] in your notification params.'
-
-
 def test_invalid_no_value(notification):
     notification['data'][0]['temperature'].pop('value')
     r = requests.post('{}'.format(notify_url), data=json.dumps(notification), headers=HEADERS_PUT)
     assert r.status_code == 400
-    assert r.text == 'Payload is missing value for temperature'
+    assert r.text == 'Payload is missing value for attribute temperature'
 
 
 @patch('translators.crate.CrateTranslator')
@@ -83,6 +75,13 @@ def test_valid_notification(MockTranslator, live_server, notification):
 
     r = requests.post('{}'.format(notify_url), data=json.dumps(notification), headers=HEADERS_PUT)
 
+    assert r.status_code == 200
+    assert r.text == 'Notification successfully processed'
+
+
+def test_valid_no_modified(notification, crate_translator):
+    notification['data'][0]['temperature']['metadata'].pop('dateModified')
+    r = requests.post('{}'.format(notify_url), data=json.dumps(notification), headers=HEADERS_PUT)
     assert r.status_code == 200
     assert r.text == 'Notification successfully processed'
 
@@ -122,6 +121,8 @@ def do_integration(entity, notify_url, orion_client, crate_translator):
 
     entities = crate_translator.query()
 
+    # Not exactly one because first insert generates 2 notifications, as explained in
+    # https://fiware-orion.readthedocs.io/en/master/user/walkthrough_apiv2/index.html#subscriptions
     assert len(entities) > 0
 
     # Note: How Quantumleap will return entities is still not well defined. This will change.
@@ -137,13 +138,3 @@ def test_integration(entity, orion_client, fresh_db, crate_translator):
     Test Reporter using input directly from an Orion notification and output directly to Cratedb.
     """
     do_integration(entity, notify_url, orion_client, crate_translator)
-
-
-# def test_dev_integration(entity, orion_client, fresh_db, crate_translator):
-#     """
-#     Leave this for easier debugging.
-#     """
-#     # Remember to sudo ifconfig lo0 alias 192.0.0.1 to get notification from containerized orion!
-#     notify_url = 'http://192.0.0.1:8668/notify'
-#     os.environ['DB_HOST'] = "0.0.0.0"
-#     do_integration(entity, notify_url, orion_client, crate_translator)

--- a/setup_dev_env.sh
+++ b/setup_dev_env.sh
@@ -1,6 +1,8 @@
 #!/usr/bin/env bash
 # Script to simplify local development and debugging.
 
+export PYTHONPATH=$PWD:$PYTHONPATH
+
 # Aliasing so that notifications from orion container reach dev localhost
 LH=192.0.0.1
 sudo ifconfig lo0 alias $LH

--- a/setup_dev_env.sh
+++ b/setup_dev_env.sh
@@ -1,0 +1,14 @@
+#!/usr/bin/env bash
+# Script to simplify local development and debugging.
+
+# Aliasing so that notifications from orion container reach dev localhost
+LH=192.0.0.1
+sudo ifconfig lo0 alias $LH
+
+export ORION_HOST=$LH
+export MONGO_HOST=$LH
+
+export QL_URL=$LH
+export CRATE_HOST=$LH
+export INFLUX_HOST=$LH
+export RETHINK_HOST=$LH

--- a/translators/crate.py
+++ b/translators/crate.py
@@ -22,7 +22,6 @@ class CrateTranslator(BaseTranslator):
         super(CrateTranslator, self).__init__(host, port, db_name)
 
         self.table_name = 'notifications'
-        self.table_created = False
         self.table_columns = None  # name:type of columns for correct querying
 
 
@@ -32,8 +31,8 @@ class CrateTranslator(BaseTranslator):
 
 
     def dispose(self, testing=False):
-        if testing and self.table_created:
-            self.cursor.execute("DROP TABLE {}".format(self.table_name))
+        if testing:
+            self.cursor.execute("DROP TABLE IF EXISTS {}".format(self.table_name))
 
         self.table_name = None
         self.table_columns = None
@@ -73,12 +72,7 @@ class CrateTranslator(BaseTranslator):
         cmd = "create table if not exists {} ( \
                         {})".format(self.table_name, columns)
 
-        try:
-            self.cursor.execute(cmd)
-        except Exception:
-            raise
-        else:
-            self.table_created = True
+        self.cursor.execute(cmd)
         return ','.join(str(c) for c in sorted(name_type.keys()))
 
 

--- a/translators/crate.py
+++ b/translators/crate.py
@@ -18,10 +18,12 @@ CRATE_TO_NGSI = dict((v, k) for (k,v) in NGSI_TO_CRATE.items())
 
 class CrateTranslator(BaseTranslator):
 
+    TABLE_NAME = 'notifications'
+
     def __init__(self, host, port=4200, db_name="ngsi-tsdb"):
         super(CrateTranslator, self).__init__(host, port, db_name)
 
-        self.table_name = 'notifications'
+        self.table_name = self.TABLE_NAME
         self.table_columns = None  # name:type of columns for correct querying
 
 

--- a/translators/fixtures.py
+++ b/translators/fixtures.py
@@ -1,39 +1,28 @@
+from conftest import CRATE_HOST, CRATE_PORT
 from translators.crate import CrateTranslator
 from translators.influx import InfluxTranslator
 from translators.rethink import RethinkTranslator
 import os
 import pytest
 
-CRATE_HOST = os.environ.get('CRATE_HOST', 'crate')
+
 INFLUX_HOST = os.environ.get('INFLUX_HOST', 'influx')
 RETHINK_HOST = os.environ.get('RETHINK_HOST', 'rethink')
 
 
 @pytest.fixture
 def influx_translator():
-    trans = InfluxTranslator(INFLUX_HOST)
-    trans.setup()
-
-    yield trans
-
-    trans.dispose()
+    with InfluxTranslator(INFLUX_HOST) as trans:
+        yield trans
 
 
 @pytest.fixture()
-def crate_translator():
-    trans = CrateTranslator(CRATE_HOST)
-    trans.setup()
-
-    yield trans
-
-    trans.dispose(testing=True)
+def crate_translator(clean_crate):
+    with CrateTranslator(host=CRATE_HOST, port=CRATE_PORT) as trans:
+        yield trans
 
 
 @pytest.fixture()
 def rethink_translator():
-    trans = RethinkTranslator(RETHINK_HOST)
-    trans.setup()
-
-    yield trans
-
-    trans.dispose()
+    with RethinkTranslator(RETHINK_HOST) as trans:
+        yield trans

--- a/translators/tests/run_tests.sh
+++ b/translators/tests/run_tests.sh
@@ -1,0 +1,6 @@
+#!/usr/bin/env bash
+
+docker-compose up -d
+sleep 8
+docker run -ti --rm --network tests_translatorstests quantumleap /bin/sh -c "pytest translators/tests"
+docker-compose down


### PR DESCRIPTION
Missing datetime in a notification is no longer critical. Let's assume notification arrival time as modification time.

PR includes cleanup of fixtures.