### PR TITLE
Add volumes to mongo and crate in Grafana experiment

### DIFF
--- a/experiments/grafana/docker-compose.yml
+++ b/experiments/grafana/docker-compose.yml
@@ -19,13 +19,6 @@ services:
     image: mongo:3.2
     ports:
       - "27017:27017"
-    deploy:
-      mode: global
-      restart_policy:
-        condition: on-failure
-      update_config:
-        parallelism: 1
-        delay: 1m30s
     volumes:
       - mongodata:/data/db
 
@@ -48,13 +41,6 @@ services:
       # Transport protocol
       - "4300:4300"
     command: -Ccluster.name=democluster -Chttp.cors.enabled=true -Chttp.cors.allow-origin="*"
-    deploy:
-      mode: global
-      restart_policy:
-        condition: on-failure
-      update_config:
-        parallelism: 1
-        delay: 1m30s
     volumes:
       - cratedata:/data
 

--- a/experiments/grafana/docker-compose.yml
+++ b/experiments/grafana/docker-compose.yml
@@ -19,6 +19,15 @@ services:
     image: mongo:3.2
     ports:
       - "27017:27017"
+    deploy:
+      mode: global
+      restart_policy:
+        condition: on-failure
+      update_config:
+        parallelism: 1
+        delay: 1m30s
+    volumes:
+      - mongodata:/data/db
 
   quantumleap:
     image: smartsdk/quantumleap
@@ -39,6 +48,15 @@ services:
       # Transport protocol
       - "4300:4300"
     command: -Ccluster.name=democluster -Chttp.cors.enabled=true -Chttp.cors.allow-origin="*"
+    deploy:
+      mode: global
+      restart_policy:
+        condition: on-failure
+      update_config:
+        parallelism: 1
+        delay: 1m30s
+    volumes:
+      - cratedata:/data
 
   grafana:
     image: grafana/grafana
@@ -48,6 +66,10 @@ services:
       - GF_INSTALL_PLUGINS=crate-datasource,grafana-clock-panel,grafana-worldmap-panel
     depends_on:
       - crate
+
+volumes:
+  mongodata:
+  cratedata:
 
 networks:
     default:


### PR DESCRIPTION
Luckily as suspected, with stack deploy and volumes "not external", the volume is not re-created when existing.

I'm adding this in this compose because it's currently being used as "reference" by some people testing QL and they've requested persistence.