### PR TITLE
Treat missing or empty body

### DIFF
--- a/reporter/reporter.py
+++ b/reporter/reporter.py
@@ -89,8 +89,16 @@ def _get_time_index(payload):
     return datetime.now().isoformat()
 
 
-@app.route('/notify', methods=['POST', 'GET'])
+@app.route('/notify', methods=['POST'])
 def notify():
+    if request.json is None:
+        return 'Discarding notification due to lack of request body. Lost in a ' \
+               'redirect maybe?', 400
+
+    if 'data' not in request.json:
+        return 'Discarding notification due to lack of request body ' \
+               'content.', 400
+
     payload = request.json['data']
     assert len(payload) == 1, 'Multiple data elements in notifications not supported yet'
     payload = payload[0]

--- a/reporter/tests/test_reporter.py
+++ b/reporter/tests/test_reporter.py
@@ -26,10 +26,70 @@ def notification():
                 'temperature': {
                     'type': 'Number',
                     'value': 25.4,
-                    'metadata': {'dateModified': {'type': 'DateTime', 'value': '2017-06-19T11:46:45.00Z'}}}
+                    'metadata': {
+                        'dateModified': {
+                            'type': 'DateTime',
+                            'value': '2017-06-19T11:46:45.00Z'}
+                    }
+                }
             }
         ]
     }
+
+
+def test_invalid_no_body():
+    r = requests.post('{}'.format(notify_url),
+                      data=json.dumps(None),
+                      headers=HEADERS_PUT)
+    assert r.status_code == 400
+    assert r.text == 'Discarding notification due to lack of request body. ' \
+                     'Lost in a redirect maybe?'
+
+
+def test_invalid_empty_body():
+    r = requests.post('{}'.format(notify_url),
+                      data=json.dumps({}),
+                      headers=HEADERS_PUT)
+    assert r.status_code == 400
+    assert r.text == 'Discarding notification due to lack of request body ' \
+                     'content.'
+
+
+def test_invalid_no_type(notification):
+    notification['data'][0].pop('type')
+    r = requests.post('{}'.format(notify_url),
+                      data=json.dumps(notification),
+                      headers=HEADERS_PUT)
+    assert r.status_code == 400
+    assert r.text == 'Entity type is required in notifications'
+
+
+def test_invalid_no_id(notification):
+    notification['data'][0].pop('id')
+    r = requests.post('{}'.format(notify_url),
+                      data=json.dumps(notification),
+                      headers=HEADERS_PUT)
+    assert r.status_code == 400
+    assert r.text == 'Entity id is required in notifications'
+
+
+def test_invalid_no_attr(notification):
+    notification['data'][0].pop('temperature')
+    r = requests.post('{}'.format(notify_url),
+                      data=json.dumps(notification),
+                      headers=HEADERS_PUT)
+    assert r.status_code == 400
+    msg = 'Received notification without attributes other than "type" and "id"'
+    assert r.text == msg
+
+
+def test_invalid_no_value(notification):
+    notification['data'][0]['temperature'].pop('value')
+    r = requests.post('{}'.format(notify_url),
+                      data=json.dumps(notification),
+                      headers=HEADERS_PUT)
+    assert r.status_code == 400
+    assert r.text == 'Payload is missing value for attribute temperature'
 
 
 def test_version():
@@ -38,40 +98,14 @@ def test_version():
     assert r.text == '0.0.1'
 
 
-def test_invalid_no_type(notification):
-    notification['data'][0].pop('type')
-    r = requests.post('{}'.format(notify_url), data=json.dumps(notification), headers=HEADERS_PUT)
-    assert r.status_code == 400
-    assert r.text == 'Entity type is required in notifications'
-
-
-def test_invalid_no_id(notification):
-    notification['data'][0].pop('id')
-    r = requests.post('{}'.format(notify_url), data=json.dumps(notification), headers=HEADERS_PUT)
-    assert r.status_code == 400
-    assert r.text == 'Entity id is required in notifications'
-
-
-def test_invalid_no_attr(notification):
-    notification['data'][0].pop('temperature')
-    r = requests.post('{}'.format(notify_url), data=json.dumps(notification), headers=HEADERS_PUT)
-    assert r.status_code == 400
-    assert r.text == 'Received notification without attributes other than "type" and "id"'
-
-
-def test_invalid_no_value(notification):
-    notification['data'][0]['temperature'].pop('value')
-    r = requests.post('{}'.format(notify_url), data=json.dumps(notification), headers=HEADERS_PUT)
-    assert r.status_code == 400
-    assert r.text == 'Payload is missing value for attribute temperature'
-
-
 @patch('translators.crate.CrateTranslator')
 def test_valid_notification(MockTranslator, live_server, notification):
     live_server.start()
     notify_url = url_for('notify', _external=True)
 
-    r = requests.post('{}'.format(notify_url), data=json.dumps(notification), headers=HEADERS_PUT)
+    r = requests.post('{}'.format(notify_url),
+                      data=json.dumps(notification),
+                      headers=HEADERS_PUT)
 
     assert r.status_code == 200
     assert r.text == 'Notification successfully processed'
@@ -79,7 +113,9 @@ def test_valid_notification(MockTranslator, live_server, notification):
 
 def test_valid_no_modified(notification, clean_crate):
     notification['data'][0]['temperature']['metadata'].pop('dateModified')
-    r = requests.post('{}'.format(notify_url), data=json.dumps(notification), headers=HEADERS_PUT)
+    r = requests.post('{}'.format(notify_url),
+                      data=json.dumps(notification),
+                      headers=HEADERS_PUT)
     assert r.status_code == 200
     assert r.text == 'Notification successfully processed'
 
@@ -119,11 +155,11 @@ def do_integration(entity, notify_url, orion_client, crate_translator):
 
     entities = crate_translator.query()
 
-    # Not exactly one because first insert generates 2 notifications, as explained in
+    # Not exactly one because first insert generates 2 notifications, see...
     # https://fiware-orion.readthedocs.io/en/master/user/walkthrough_apiv2/index.html#subscriptions
     assert len(entities) > 0
 
-    # Note: How Quantumleap will return entities is still not well defined. This will change.
+    # Note: How Quantumleap will return entities is still not well defined.
     entities[0].pop(CrateTranslator.TIME_INDEX_NAME)
     entity.pop('pressure')
     entity['temperature'].pop('metadata')
@@ -133,12 +169,14 @@ def do_integration(entity, notify_url, orion_client, crate_translator):
 
 def test_integration(entity, orion_client, clean_mongo, crate_translator):
     """
-    Test Reporter using input directly from an Orion notification and output directly to Cratedb.
+    Test Reporter using input directly from an Orion notification and output
+    directly to Cratedb.
     """
     do_integration(entity, notify_url, orion_client, crate_translator)
 
 
-def test_air_quality_observed(air_quality_observed, orion_client, clean_mongo, crate_translator):
+def test_air_quality_observed(air_quality_observed, orion_client, clean_mongo,
+                              crate_translator):
     entity = air_quality_observed
     subscription = {
         "description": "Test subscription",
@@ -169,6 +207,6 @@ def test_air_quality_observed(air_quality_observed, orion_client, clean_mongo, c
 
     entities = crate_translator.query()
 
-    # Not exactly one because first insert generates 2 notifications, as explained in
+    # Not exactly one because first insert generates 2 notifications, see...
     # https://fiware-orion.readthedocs.io/en/master/user/walkthrough_apiv2/index.html#subscriptions
     assert len(entities) > 0


### PR DESCRIPTION
Avoid errors due to missing or empty body in notify requests. (which by the way can only be POSTed to)