### PR TITLE
Update crate version + let users ignore entity_type

### DIFF
--- a/deps.env
+++ b/deps.env
@@ -1,11 +1,11 @@
 # Tested versions (docker tags) of microservices dependencies
 
 export MONGO_VERSION=3.2
-export ORION_VERSION=1.13.0
+export ORION_VERSION=1.15.1
 
 export INFLUX_VERSION=1.2.2
 export RETHINK_VERSION=2.3.5
-export CRATE_VERSION=1.0.5
+export CRATE_VERSION=3.0.5
 
 export REDIS_VERSION=3
 

--- a/docker/docker-compose-dev.yml
+++ b/docker/docker-compose-dev.yml
@@ -3,7 +3,7 @@ version: '3'
 services:
 
   orion:
-    image: fiware/orion:1.13.0
+    image: fiware/orion:${ORION_VERSION:-1.15.1}
     ports:
       - "1026:1026"
     command: -logLevel DEBUG -noCache -dbhost mongo
@@ -37,13 +37,14 @@ services:
       - REDIS_PORT=6379
 
   crate:
-    image: crate:1.0.5
+    image: crate:${CRATE_VERSION:-3.0.5}
+    command: crate -Clicense.enterprise=false -Cauth.host_based.enabled=false
+      -Ccluster.name=democluster -Chttp.cors.enabled=true -Chttp.cors.allow-origin="*"
     ports:
       # Admin UI
       - "4200:4200"
       # Transport protocol
       - "4300:4300"
-    command: -Ccluster.name=democluster -Chttp.cors.enabled=true -Chttp.cors.allow-origin="*"
     volumes:
       - cratedata:/data
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -15,7 +15,7 @@ influxdb==4.0.0
 itsdangerous==0.24
 Jinja2==2.9.6
 jsonschema==2.6.0
-locustio==0.8
+locustio==0.8a1
 MarkupSafe==1.0
 matplotlib==2.0.1
 msgpack-python==0.4.8

--- a/requirements.txt
+++ b/requirements.txt
@@ -2,7 +2,7 @@ appdirs==1.4.3
 click==6.7
 clickclick==1.2.1
 connexion==1.1.8
-crate==0.19.1
+crate==0.22.1
 cycler==0.10.0
 decorator==4.1.2
 Flask==0.12.1

--- a/requirements.txt
+++ b/requirements.txt
@@ -15,8 +15,7 @@ influxdb==4.0.0
 itsdangerous==0.24
 Jinja2==2.9.6
 jsonschema==2.6.0
-locust==0.8
-locustio==0.8a1
+locustio==0.8
 MarkupSafe==1.0
 matplotlib==2.0.1
 msgpack-python==0.4.8

--- a/src/exceptions/exceptions.py
+++ b/src/exceptions/exceptions.py
@@ -1,0 +1,23 @@
+
+
+class QLError(Exception):
+    """
+    Error raised in QuantumLeap usage.
+    """
+
+
+class NGSIUsageError(QLError):
+    """
+    Errors due to wrong NGSI usage.
+    """
+
+
+class AmbiguousNGSIIdError(NGSIUsageError):
+    """
+    Examples include querying for an entity_id without specifying entity_type
+    being entity_id not unique across entity_types.
+    """
+    def __init__(self, entity_id=''):
+        msg = "There are multiple entities with the given entity_id {}. " \
+              "Please specify entity_type."
+        NGSIUsageError.__init__(self, msg.format(entity_id))

--- a/src/reporter/delete.py
+++ b/src/reporter/delete.py
@@ -1,44 +1,38 @@
+from exceptions.exceptions import AmbiguousNGSIIdError
 from flask import request
 from translators import crate
 
 
 def delete_entity(entity_id, type_=None, from_date=None, to_date=None):
-    if type_ is None:
-        r = {
-            "error": "Not Implemented",
-            "description": "For now, you must always specify entity type."
-        }
-        return r, 400
-
     fiware_s = request.headers.get('fiware-service', None)
     fiware_sp = request.headers.get('fiware-servicepath', None)
 
-    with crate.CrateTranslatorInstance() as trans:
-        deleted = trans.delete_entity(entity_id=entity_id,
-                                      entity_type=type_,
-                                      from_date=from_date,
-                                      to_date=to_date,
-                                      fiware_service=fiware_s,
-                                      fiware_servicepath=fiware_sp,)
-        if deleted == 0:
-            r = {
-                "error": "Not Found",
-                "description": "No records were found for such query."
-            }
-            return r, 404
+    try:
+        with crate.CrateTranslatorInstance() as trans:
+            deleted = trans.delete_entity(entity_id=entity_id,
+                                          entity_type=type_,
+                                          from_date=from_date,
+                                          to_date=to_date,
+                                          fiware_service=fiware_s,
+                                          fiware_servicepath=fiware_sp,)
+    except AmbiguousNGSIIdError as e:
+        return {
+            "error": "AmbiguousNGSIIdError",
+            "description": str(e)
+        }, 409
 
-        if deleted > 0:
-            return '{} records successfully deleted.'.format(deleted), 204
+    if deleted == 0:
+        r = {
+            "error": "Not Found",
+            "description": "No records were found for such query."
+        }
+        return r, 404
+
+    if deleted > 0:
+        return '{} records successfully deleted.'.format(deleted), 204
 
 
 def delete_entities(entity_type, from_date=None, to_date=None):
-    if entity_type is None:
-        r = {
-            "error": "Not Implemented",
-            "description": "For now, you must always specify entity type."
-        }
-        return r, 400
-
     fiware_s = request.headers.get('fiware-service', None)
     fiware_sp = request.headers.get('fiware-servicepath', None)
 

--- a/src/reporter/tests/docker-compose.yml
+++ b/src/reporter/tests/docker-compose.yml
@@ -40,6 +40,7 @@ services:
 
   crate:
     image: crate:${CRATE_VERSION}
+    command: crate -Clicense.enterprise=false -Cauth.host_based.enabled=false
     ports:
       # Admin UI
       - "4200:4200"

--- a/src/reporter/tests/docker-compose.yml
+++ b/src/reporter/tests/docker-compose.yml
@@ -41,6 +41,7 @@ services:
   crate:
     image: crate:${CRATE_VERSION}
     command: crate -Clicense.enterprise=false -Cauth.host_based.enabled=false
+      -Ccluster.name=democluster -Chttp.cors.enabled=true -Chttp.cors.allow-origin="*"
     ports:
       # Admin UI
       - "4200:4200"

--- a/src/reporter/tests/test_1T1ENA.py
+++ b/src/reporter/tests/test_1T1ENA.py
@@ -341,15 +341,3 @@ def test_not_found():
         "error": "Not Found",
         "description": "No records were found for such query."
     }
-
-
-def test_tmp_no_type():
-    """
-    For now specifying entity type is mandatory
-    """
-    r = requests.get(query_url(), params={})
-    assert r.status_code == 400, r.text
-    assert r.json() == {
-        "error": "Not Implemented",
-        "description": "For now, you must always specify entity type."
-    }

--- a/src/reporter/tests/test_version.py
+++ b/src/reporter/tests/test_version.py
@@ -7,5 +7,5 @@ def test_version():
     r = requests.get('{}'.format(version_url))
     assert r.status_code == 200, r.text
     assert r.json() == {
-        "version": "0.3.1"
+        "version": "0.3.2"
     }

--- a/src/reporter/tests/utils.py
+++ b/src/reporter/tests/utils.py
@@ -8,15 +8,17 @@ def notify_url():
     return "{}/notify".format(QL_URL)
 
 
-def insert_test_data(translator, entity_types, n_entities, n_days):
+def insert_test_data(translator, entity_types, n_entities, n_days,
+                     entity_id=None):
     assert isinstance(entity_types, list)
 
     def get_notification(et, ei, temp_value, mod_value):
+        eid = entity_id or '{}{}'.format(et, ei)
         return {
             'subscriptionId': '5947d174793fe6f7eb5e3961',
             'data': [
                 {
-                    'id': '{}{}'.format(et, ei),
+                    'id': eid,
                     'type': et,
                     'temperature': {
                         'type': 'Number',

--- a/src/reporter/version.py
+++ b/src/reporter/version.py
@@ -1,5 +1,5 @@
 
 def version():
     return {
-        'version': '0.3.1'
+        'version': '0.3.2'
     }

--- a/src/translators/crate.py
+++ b/src/translators/crate.py
@@ -104,9 +104,9 @@ class CrateTranslator(base_translator.BaseTranslator):
         :return: iterable(NGSI Entity)
             Iterable over the translated NGSI entities.
         """
-        stmt = "select entity_attrs from {} where table_name = '{}'".format(
-            METADATA_TABLE_NAME, table_name)
-        self.cursor.execute(stmt)
+        stmt = "select entity_attrs from {} " \
+               "where table_name = ?".format(METADATA_TABLE_NAME)
+        self.cursor.execute(stmt, [table_name,])
         res = self.cursor.fetchall()
 
         if len(res) != 1:
@@ -348,8 +348,8 @@ class CrateTranslator(base_translator.BaseTranslator):
             persisted_metadata = {}
         else:
             # Bring translation table!
-            stmt = "select entity_attrs from {} where table_name = '{}'"
-            self.cursor.execute(stmt.format(METADATA_TABLE_NAME, table_name))
+            stmt = "select entity_attrs from {} where table_name = ?"
+            self.cursor.execute(stmt.format(METADATA_TABLE_NAME), [table_name,])
 
             # By design, one entry per table_name
             res = self.cursor.fetchall()
@@ -597,11 +597,9 @@ class CrateTranslator(base_translator.BaseTranslator):
             return 0
 
         # Delete entry from metadata table
-        op = "delete from {} where table_name = '{}'".format(
-            METADATA_TABLE_NAME, table_name
-        )
+        op = "delete from {} where table_name = ?".format(METADATA_TABLE_NAME)
         try:
-            self.cursor.execute(op)
+            self.cursor.execute(op, [table_name,])
         except ProgrammingError as e:
             # What if this one fails and previous didn't?
             logging.debug("{}".format(e))
@@ -636,8 +634,8 @@ class CrateTranslator(base_translator.BaseTranslator):
         matching_types = []
         for et in all_types:
             stmt = "select distinct(entity_type) from {} " \
-                   "where entity_id = '{}'".format(et, entity_id)
-            self.cursor.execute(stmt)
+                   "where entity_id = ?".format(et)
+            self.cursor.execute(stmt, [entity_id,])
             types = [t[0] for t in self.cursor.fetchall()]
             matching_types.extend(types)
 

--- a/src/translators/tests/docker-compose.yml
+++ b/src/translators/tests/docker-compose.yml
@@ -16,6 +16,7 @@ services:
   crate:
     image: crate:${CRATE_VERSION}
     command: crate -Clicense.enterprise=false -Cauth.host_based.enabled=false
+      -Ccluster.name=democluster -Chttp.cors.enabled=true -Chttp.cors.allow-origin="*"
     ports:
       # Admin UI
       - "4200:4200"

--- a/src/translators/tests/docker-compose.yml
+++ b/src/translators/tests/docker-compose.yml
@@ -15,6 +15,7 @@ services:
 
   crate:
     image: crate:${CRATE_VERSION}
+    command: crate -Clicense.enterprise=false -Cauth.host_based.enabled=false
     ports:
       # Admin UI
       - "4200:4200"

--- a/src/translators/tests/test_crate.py
+++ b/src/translators/tests/test_crate.py
@@ -6,8 +6,13 @@ from utils.common import *
 import statistics
 
 
+def test_db_version(translator):
+    version = translator.get_db_version()
+    assert version == '3.0.5'
+
+
 def test_insert(translator):
-    entities = create_random_entities(1, 2, 10, use_time=True, use_geo=True)
+    entities = create_random_entities(1, 2, 3, use_time=True, use_geo=True)
     result = translator.insert(entities)
     assert result.rowcount == len(entities)
 


### PR DESCRIPTION
To let users ignore entity_type when entity_id is unique I though of using a more recent feature of crate, but in the end decided not to depend on those for now. Upgrading crate version was still worth pursuing. Same thing for Orion.