### PR TITLE
Quote Crate Identifiers

### DIFF
--- a/src/reporter/tests/test_entities_with_odd_chars.py
+++ b/src/reporter/tests/test_entities_with_odd_chars.py
@@ -1,0 +1,82 @@
+from conftest import QL_URL
+import pytest
+import requests
+import time
+import urllib
+from .utils import send_notifications
+
+
+def mk_entity(eid, entity_type, attr_name):
+    return {
+        'id': eid,
+        'type': entity_type,
+        attr_name: {
+            'type': 'Text',
+            'value': 'test'
+        }
+    }
+
+
+def insert_entity(entity):
+    notification_data = [{'data': [entity]}]
+    send_notifications(notification_data)
+
+    time.sleep(2)
+
+
+def query_entity(entity_id, attr_name):
+    escaped_attr_name = urllib.parse.quote(attr_name)
+    url = "{}/entities/{}/attrs/{}".format(QL_URL, entity_id, escaped_attr_name)
+    response = requests.get(url)
+    assert response.status_code == 200
+    return response.json().get('data', {})
+
+
+def delete_entities(entity_type):
+    delete_url = "{}/types/{}".format(QL_URL, entity_type)
+    response = requests.delete(delete_url)
+    assert response.ok
+
+
+def run_test(entity_type, attr_name):
+    entity = mk_entity('d1', entity_type, attr_name)
+
+    insert_entity(entity)
+
+    query_result = query_entity(entity['id'], attr_name)
+    query_result.pop('index', None)
+    assert query_result == {
+        'attrName': attr_name,
+        'entityId': entity['id'],
+        'values': [entity[attr_name]['value']]
+    }
+
+    delete_entities(entity['type'])
+
+
+odd_chars = ['-', '+', '@']
+# TODO: test other chars too, e.g. ':'
+# Note that you can't use certain chars at all, even if quoted. Two
+# such chars are '.' and  ' '. So for example, CrateDB bombs out on
+# `create table "x.y" (...)` or `create table "x y" (...)`
+
+
+@pytest.mark.parametrize('char', odd_chars)
+def test_odd_char_in_entity_type(char):
+    entity_type = 'test{}device'.format(char)
+    attr_name = 'plain_name'
+    run_test(entity_type, attr_name)
+
+
+@pytest.mark.parametrize('char', odd_chars)
+def test_odd_char_in_attr_name(char):
+    entity_type = 'test_device'
+    attr_name = 'weird{}name'.format(char)
+    run_test(entity_type, attr_name)
+
+
+@pytest.mark.parametrize('char', odd_chars)
+def test_odd_char_in_entity_type_and_attr_name(char):
+    entity_type = 'test{}device'.format(char)
+    attr_name = 'weird{}name'.format(char)
+    run_test(entity_type, attr_name)

--- a/src/reporter/tests/test_entities_with_odd_chars.py
+++ b/src/reporter/tests/test_entities_with_odd_chars.py
@@ -54,11 +54,10 @@ def run_test(entity_type, attr_name):
     delete_entities(entity['type'])
 
 
-odd_chars = ['-', '+', '@']
-# TODO: test other chars too, e.g. ':'
-# Note that you can't use certain chars at all, even if quoted. Two
-# such chars are '.' and  ' '. So for example, CrateDB bombs out on
-# `create table "x.y" (...)` or `create table "x y" (...)`
+odd_chars = ['-', '+', '@', ':']
+# Note that you can't use certain chars at all, even if quoted. Three
+# such chars are '.', '#' and  ' '. So for example, CrateDB bombs out
+# on `create table "x.y" (...)` or `create table "x y" (...)`
 
 
 @pytest.mark.parametrize('char', odd_chars)

--- a/src/translators/crate.py
+++ b/src/translators/crate.py
@@ -144,9 +144,9 @@ class CrateTranslator(base_translator.BaseTranslator):
         https://crate.io/docs/crate/reference/en/latest/sql/general/lexical-structure.html#key-words-and-identifiers
         ), both schema and table name are prefixed.
         """
-        et = "{}{}".format(TYPE_PREFIX, entity_type.lower())
+        et = '"{}{}"'.format(TYPE_PREFIX, entity_type.lower())
         if fiware_service:
-            return "{}{}.{}".format(TENANT_PREFIX, fiware_service.lower(), et)
+            return '"{}{}".{}'.format(TENANT_PREFIX, fiware_service.lower(), et)
         return et
 
 
@@ -260,7 +260,10 @@ class CrateTranslator(base_translator.BaseTranslator):
         self._update_metadata_table(table_name, original_attrs)
 
         # Create Data Table
-        columns = ', '.join('{} {}'.format(cn, ct) for cn, ct in table.items())
+        # NOTE. CrateDB identifiers (like column and table names) become case
+        # sensitive when quoted like we do below in the CREATE TABLE statement.
+        columns = ', '.join('"{}" {}'.format(cn.lower(), ct)
+                            for cn, ct in table.items())
         stmt = "create table if not exists {} ({}) with " \
                "(number_of_replicas = '2-all')".format(table_name, columns)
         self.cursor.execute(stmt)
@@ -275,7 +278,7 @@ class CrateTranslator(base_translator.BaseTranslator):
 
         # Insert entities data
         p1 = table_name
-        p2 = ', '.join(col_names)
+        p2 = ', '.join(['"{}"'.format(c.lower()) for c in col_names])
         p3 = ','.join(['?'] * len(col_names))
         stmt = "insert into {} ({}) values ({})".format(p1, p2, p3)
         self.cursor.executemany(stmt, entries)
@@ -359,7 +362,7 @@ class CrateTranslator(base_translator.BaseTranslator):
         """
         op = "select distinct table_name from {} ".format(METADATA_TABLE_NAME)
         if fiware_service:
-            where = "where table_name ~* '{}{}[.].*'"
+            where = "where table_name ~* '\"{}{}\"[.].*'"
             op += where.format(TENANT_PREFIX, fiware_service.lower())
         try:
             self.cursor.execute(op)
@@ -383,12 +386,12 @@ class CrateTranslator(base_translator.BaseTranslator):
                         aggr_period, self.TIME_INDEX_NAME, self.TIME_INDEX_NAME)
                 )
             # TODO: https://github.com/smartsdk/ngsi-timeseries-api/issues/106
-            m = "{}({}) as {}"
+            m = '{}("{}") as "{}"'
             attrs.extend(m.format(aggr_method, a, a) for a in set(attr_names))
 
         else:
             attrs.append(self.TIME_INDEX_NAME)
-            attrs.extend(str(a) for a in attr_names)
+            attrs.extend('"{}"'.format(a) for a in attr_names)
 
         select = ','.join(attrs)
         return select
@@ -856,10 +859,10 @@ class CrateTranslator(base_translator.BaseTranslator):
         """
         # Filter using tenant information
         if fiware_service is None:
-            wc = "where table_name NOT like '{}%.%'".format(TENANT_PREFIX)
+            wc = "where table_name NOT like '\"{}%.%'".format(TENANT_PREFIX)
         else:
             # See _et2tn
-            prefix = "{}{}".format(TENANT_PREFIX, fiware_service.lower())
+            prefix = '"{}{}"'.format(TENANT_PREFIX, fiware_service.lower())
             wc = "where table_name like '{}.%'".format(prefix)
 
         stmt = "select distinct(table_name) from {} {}".format(

--- a/src/translators/tests/test_crate_replication.py
+++ b/src/translators/tests/test_crate_replication.py
@@ -1,4 +1,4 @@
-from translators.crate import METADATA_TABLE_NAME
+from translators.crate import METADATA_TABLE_NAME, TYPE_PREFIX
 from conftest import crate_translator as translator
 from utils.common import create_random_entities
 
@@ -15,9 +15,11 @@ def test_default_replication(translator):
 
     translator.insert(entities)
 
+    et = '{}{}'.format(TYPE_PREFIX, e_type.lower())
+    # same as in translator._et2tn but without double quotes
     op = "select number_of_replicas from information_schema.tables where " \
          "table_name = '{}'"
-    translator.cursor.execute(op.format(translator._et2tn(e_type)))
+    translator.cursor.execute(op.format(et))
     res = translator.cursor.fetchall()
     assert res[0] == ['2-all']
 


### PR DESCRIPTION
This PR implements quoting of CrateDB identifiers.

Entity types used to get converted to table names without quoting them so if an entity type contained a character that Crate doesn't allow in an identifier, QL would fail to save the entity because of the SQL exception raised by Crate on inserting the data. Ditto for attribute names. For an example of this issue, see #128.

This PR remedies that by quoting all identifiers (table names and columns) passed down to Crate when performing CRUD operations. But take heed: Crate doesn't allow some characters in identifiers at all, even if the identifier is quoted. Three such characters are `.`, `#` and  ` ` (whitespace). So for example, the following statements fail:

    create table "x.y" (z string)
    create table "x y" (z string)
    create table "x#y" (z string)

To some extent this is to be expected as Crate [forbids][create-table] these characters in table names. However, it isn't clear (at least to me) what is the actual set of characters allowed in unquoted identifiers and that allowed in quoted identifiers. Surely the two sets are not the same as the first statement below fails while the second succeeds:

    create table x:y (z string)    -- fails
    create table "x:y" (z string)  -- succeeds

Note that `:` is not mentioned as a forbidden character in the [Create Table][create-table] and [Lexical Structure][lexical-structure] sections of the Crate documentation.

In conclusion, this PR is intended as a best-effort stopgap solution until we put in place a more sophisticated alternative based on bidirectional encoding of entity types/attribute names to Crate identifiers---i.e. a bijection `NGSI-Identifier ⟶ Crate-Identifier` which would also allow us to get rid of the current metadata translation map and thus improve query performance as an added benefit.



[create-table]: https://crate.io/docs/crate/reference/en/latest/general/ddl/create-table.html
[lexical-structure]: https://crate.io/docs/crate/reference/en/latest/sql/general/lexical-structure.html#sql-lexical
