### PR TITLE
Time index selection

### DIFF
--- a/Pipfile
+++ b/Pipfile
@@ -6,6 +6,7 @@ name = "pypi"
 [packages]
 connexion = "~=1.1"
 crate = "~=0.22"
+python-dateutil = ">=2.7"
 flask = "~=0.12"
 geocoder = "~=1.33"
 geojson = "~=2.4"

--- a/Pipfile.lock
+++ b/Pipfile.lock
@@ -1,7 +1,7 @@
 {
     "_meta": {
         "hash": {
-            "sha256": "e1dc8073d2733b555226f40268a8b339af6c77e9ad89cfbf0824a85b3da48598"
+            "sha256": "4a33a5f38735c73186f90433ab72ae2a59998b33e8e82c7626a334c8eab2832e"
         },
         "pipfile-spec": 6,
         "requires": {
@@ -376,10 +376,11 @@
         },
         "python-dateutil": {
             "hashes": [
-                "sha256:063df5763652e21de43de7d9e00ccf239f953a832941e37be541614732cdfc93",
-                "sha256:88f9287c0174266bb0d8cedd395cfba9c58e87e5ad86b2ce58859bc11be3cf02"
+                "sha256:7e6584c74aeed623791615e26efd690f29817a27c73085b78e4bad02493df2fb",
+                "sha256:c89805f6f4d64db21ed966fda138f8a5ed7a4fdbc1a8ee329ce1b74e3c74da9e"
             ],
-            "version": "==2.7.5"
+            "index": "pypi",
+            "version": "==2.8.0"
         },
         "pytz": {
             "hashes": [

--- a/specification/quantumleap.yml
+++ b/specification/quantumleap.yml
@@ -591,6 +591,14 @@ paths:
           description: "Minimal period of time in seconds which must elapse between two
           consecutive notifications. This is the value QL will use for the throttling
           field when creating the subscription. If not specified, it defaults to 1."
+        - in: query
+          name: timeIndexAttribute
+          required: false
+          type: string
+          description: "The name of a custom attribute to be used as a time index. On
+          receiving notifications containing this attribute, QL will use its value as
+          a time series index for the entity being notified. If specified, it should
+          refer to an entity attribute whose value is an ISO 8601 timestamp."
         - $ref: '#/parameters/fiwareService'
         - $ref: '#/parameters/fiwareServicePath'
       tags:

--- a/src/reporter/reporter.py
+++ b/src/reporter/reporter.py
@@ -261,7 +261,8 @@ def subscribe(orion_url,
               attributes=None,
               observed_attributes=None,
               notified_attributes=None,
-              throttling=None):
+              throttling=None,
+              time_index_attribute=None):
     # Validate Orion
     try:
         r = requests.get(orion_url)
@@ -280,7 +281,7 @@ def subscribe(orion_url,
         quantumleap_url,
         entity_type, entity_id, id_pattern,
         attributes, observed_attributes, notified_attributes,
-        throttling)
+        throttling, time_index_attribute)
 
     # Send subscription
     endpoint = '{}/subscriptions'.format(orion_url)

--- a/src/reporter/reporter.py
+++ b/src/reporter/reporter.py
@@ -26,7 +26,6 @@ attributes.
 interest and make QL actually perform the corresponding subscription to orion.
 I.e, QL must be told where orion is.
 """
-from datetime import datetime
 from flask import request
 from geocoding.geocache import GeoCodingCache
 from requests import RequestException
@@ -38,6 +37,7 @@ import logging
 import os
 import requests
 from reporter.subscription_builder import build_subscription
+from reporter.timex import select_time_index_value_as_iso
 from geocoding.location import normalize_location
 
 
@@ -99,40 +99,6 @@ def _validate_payload(payload):
                 'Payload is missing value for attribute {}'.format(attr))
 
 
-def _get_time_index(payload):
-    """
-    :param payload:
-        The received json data in the notification.
-
-    :return: str
-        The notification time index. E.g: '2017-06-29T14:47:50.844'
-
-    The strategy for now is simple. Received notifications are expected to have
-    the dateModified field
-    (http://docs.orioncontextbroker.apiary.io/#introduction/specification/virtual-attributes)
-    If the notification lacks this attribute, we try using the "latest" of the
-    modification times of any of the attributes in the notification. If there
-    isn't any, the notification received time will be assumed.
-
-    In future, this could be enhanced with customs notifications where user
-    specifies which attribute is to be used as "time index".
-    """
-    if 'dateModified' in payload:
-        return payload['dateModified']['value']
-
-    # Orion did not include dateModified at the entity level.
-    # Let's use the newest of the changes in any of the attributes.
-    dates = set([])
-    for attr in iter_entity_attrs(payload):
-        if 'dateModified' in payload[attr].get('metadata', {}):
-            dates.add(payload[attr]['metadata']['dateModified']['value'])
-    if dates:
-        return sorted(dates)[-1]
-
-    # Finally, assume current timestamp as dateModified
-    return datetime.now().isoformat()
-
-
 def notify():
     if request.json is None:
         return 'Discarding notification due to lack of request body. ' \
@@ -155,7 +121,8 @@ def notify():
         return error, 400
 
     # Add TIME_INDEX attribute
-    payload[CrateTranslator.TIME_INDEX_NAME] = _get_time_index(payload)
+    payload[CrateTranslator.TIME_INDEX_NAME] = \
+        select_time_index_value_as_iso(request.headers, payload)
 
     # Add GEO-DATE if enabled
     add_geodata(payload)

--- a/src/reporter/subscription_builder.py
+++ b/src/reporter/subscription_builder.py
@@ -1,10 +1,12 @@
 from utils.subscription_dsl import *
+from .timex import TIME_INDEX_HEADER_NAME
 
 
 def build_subscription(quantumleap_url,
                        etype, eid, eid_pattern,
                        attributes, observed_attributes, notified_attributes,
-                       throttling_secs):
+                       throttling_secs,
+                       time_index_attribute=None):
     tree = subscription(
         description('Created by QuantumLeap {}.'.format(quantumleap_url)),
         subject(
@@ -19,11 +21,27 @@ def build_subscription(quantumleap_url,
             )
         ),
         notification(
-            url('{}/notify'.format(quantumleap_url)),
-            metadata(['dateCreated', 'dateModified']),
+            build_notification_target(quantumleap_url, time_index_attribute),
+            metadata(['dateCreated', 'dateModified', 'TimeInstant']),
             attrs(first_of(attributes, notified_attributes))
         ),
         throttling(throttling_secs)
     )
 
     return tree.to_dict()
+
+
+def build_notification_target(quantumleap_url, time_index_attribute):
+    notification_endpoint = '{}/notify'.format(quantumleap_url)
+    if time_index_attribute:
+        return custom(
+                   notification_endpoint,
+                   headers(
+                       time_index_header(time_index_attribute)
+                   )
+                )
+    return url(notification_endpoint)
+
+
+def time_index_header(time_index_attribute):
+    return http_header(TIME_INDEX_HEADER_NAME, time_index_attribute)

--- a/src/reporter/tests/test_subscription_builder.py
+++ b/src/reporter/tests/test_subscription_builder.py
@@ -1,6 +1,7 @@
 import pytest
 
 from reporter.subscription_builder import build_subscription
+from reporter.timex import TIME_INDEX_HEADER_NAME
 
 
 def test_bare_subscription():
@@ -20,7 +21,7 @@ def test_bare_subscription():
             'http': {
                 'url': 'http://ql/notify'
             },
-            'metadata': ['dateCreated', 'dateModified']
+            'metadata': ['dateCreated', 'dateModified', 'TimeInstant']
         },
         'throttling': 1
     }
@@ -46,7 +47,7 @@ def test_entity_type():
             'http': {
                 'url': 'http://ql/notify'
             },
-            'metadata': ['dateCreated', 'dateModified']
+            'metadata': ['dateCreated', 'dateModified', 'TimeInstant']
         },
         'throttling': 1
     }
@@ -71,7 +72,7 @@ def test_entity_id():
             'http': {
                 'url': 'http://ql/notify'
             },
-            'metadata': ['dateCreated', 'dateModified']
+            'metadata': ['dateCreated', 'dateModified', 'TimeInstant']
         },
         'throttling': 1
     }
@@ -101,7 +102,7 @@ def test_attributes(attrs):
                 'url': 'http://ql/notify'
             },
             'attrs': attrs.split(','),
-            'metadata': ['dateCreated', 'dateModified']
+            'metadata': ['dateCreated', 'dateModified', 'TimeInstant']
         },
         'throttling': 1
     }
@@ -130,7 +131,7 @@ def test_observed_attributes(attrs):
             'http': {
                 'url': 'http://ql/notify'
             },
-            'metadata': ['dateCreated', 'dateModified']
+            'metadata': ['dateCreated', 'dateModified', 'TimeInstant']
         },
         'throttling': 1
     }
@@ -157,7 +158,7 @@ def test_notified_attributes(attrs):
                 'url': 'http://ql/notify'
             },
             'attrs': attrs.split(','),
-            'metadata': ['dateCreated', 'dateModified']
+            'metadata': ['dateCreated', 'dateModified', 'TimeInstant']
         },
         'throttling': 1
     }
@@ -182,7 +183,7 @@ def test_throttling():
             'http': {
                 'url': 'http://ql/notify'
             },
-            'metadata': ['dateCreated', 'dateModified']
+            'metadata': ['dateCreated', 'dateModified', 'TimeInstant']
         },
         'throttling': 123
     }
@@ -207,7 +208,7 @@ def test_entity_id_overrides_pattern():
             'http': {
                 'url': 'http://ql/notify'
             },
-            'metadata': ['dateCreated', 'dateModified']
+            'metadata': ['dateCreated', 'dateModified', 'TimeInstant']
         },
         'throttling': 1
     }
@@ -236,7 +237,7 @@ def test_all_attributes():
                 'url': 'http://ql/notify'
             },
             'attrs': ['b', 'c'],
-            'metadata': ['dateCreated', 'dateModified']
+            'metadata': ['dateCreated', 'dateModified', 'TimeInstant']
         },
         'throttling': 1
     }
@@ -270,7 +271,36 @@ def test_attributes_overrides_other_attributes(observed, notified):
                 'url': 'http://ql/notify'
             },
             'attrs': ['x'],
-            'metadata': ['dateCreated', 'dateModified']
+            'metadata': ['dateCreated', 'dateModified', 'TimeInstant']
+        },
+        'throttling': 1
+    }
+
+    assert actual == expected
+
+
+def test_subscription_with_time_index():
+    actual = build_subscription(
+        quantumleap_url='http://ql',
+        etype=None, eid=None, eid_pattern=None,
+        attributes=None, observed_attributes=None, notified_attributes=None,
+        throttling_secs=None,
+        time_index_attribute='my-time-index-attr-name')
+    expected = {
+        'description': 'Created by QuantumLeap http://ql.',
+        'subject': {
+            'entities': [{
+                'idPattern': '.*'
+            }]
+        },
+        'notification': {
+            'httpCustom': {
+                'url': 'http://ql/notify',
+                'headers': {
+                    TIME_INDEX_HEADER_NAME: 'my-time-index-attr-name'
+                }
+            },
+            'metadata': ['dateCreated', 'dateModified', 'TimeInstant']
         },
         'throttling': 1
     }

--- a/src/reporter/tests/test_time_format.py
+++ b/src/reporter/tests/test_time_format.py
@@ -1,10 +1,9 @@
-import time
-
 from conftest import crate_translator as translator
 from reporter.tests.test_1T1E1A import query_url as query_1T1E1A, \
     assert_1T1E1A_response
 from reporter.tests.utils import get_notification, send_notifications
 import requests
+import time
 
 
 def check_time_index(input_index, expected_index=None):
@@ -56,22 +55,6 @@ def test_index_iso_with_time_zone(translator):
         '2010-10-10T09:09:00.792+02:00',
         '2010-10-10T09:09:01.792+02:00',
         '2010-10-10T09:09:02.792+02:00',
-    ]
-    expected_index = [
-        '2010-10-10T07:09:00.792',
-        '2010-10-10T07:09:01.792',
-        '2010-10-10T07:09:02.792',
-    ]
-    check_time_index(input_index, expected_index)
-
-
-def test_index_with_millis(translator):
-    # If notifications uses millis, QL responds in millis (still UTC)
-    # #97: Fix this API documentation inconsistency. expected should be input
-    input_index = [
-        '1286687340792',
-        '1286687341792',
-        '1286687342792',
     ]
     expected_index = [
         '2010-10-10T07:09:00.792',

--- a/src/reporter/tests/test_timex.py
+++ b/src/reporter/tests/test_timex.py
@@ -1,0 +1,146 @@
+from datetime import *
+from reporter.timex import *
+
+
+def build_notification(custom, ti, dm, mti, mdm, a1_ti, a1_dm, a2_ti, a2_dm):
+    return {
+        'customTimeIndex': {
+            'value': custom
+        },
+        'TimeInstant': {
+            'value': ti
+        },
+        'dateModified': {
+            'value': dm
+        },
+        'metadata': {
+            'TimeInstant': {
+                'value': mti
+            },
+            'dateModified': {
+                'value': mdm
+            }
+        },
+        'a1': {
+            'metadata': {
+                'TimeInstant': {
+                    'value': a1_ti
+                },
+                'dateModified': {
+                    'value': a1_dm
+                }
+            }
+        },
+        'a2': {
+            'metadata': {
+                'TimeInstant': {
+                    'value': a2_ti
+                },
+                'dateModified': {
+                    'value': a2_dm
+                }
+            }
+        }
+    }
+
+
+def build_notification_timepoints(base_point):
+    ts = []
+    for k in range(9):
+        d = base_point + timedelta(days=k)
+        ts.append(d.isoformat())
+    return ts
+
+
+def test_custom_index_takes_priority():
+    headers = {
+        TIME_INDEX_HEADER_NAME: 'customTimeIndex'
+    }
+    custom_time_index_value = datetime(2019, 1, 1)
+    ts = build_notification_timepoints(custom_time_index_value)
+    notification = build_notification(*ts)
+
+    assert custom_time_index_value == \
+        select_time_index_value(headers, notification)
+
+
+def test_skip_custom_index_if_it_has_no_value():
+    headers = {
+        TIME_INDEX_HEADER_NAME: 'customTimeIndex'
+    }
+    base_point = datetime(2019, 1, 1)
+    ts = build_notification_timepoints(base_point)
+    ts[0] = None  # custom index slot
+    notification = build_notification(*ts)
+
+    assert ts[1] == \
+        select_time_index_value(headers, notification).isoformat()
+
+
+def test_use_time_instant():
+    headers = {}
+    base_point = datetime(2019, 1, 1)
+    ts = build_notification_timepoints(base_point)
+    notification = build_notification(*ts)
+
+    assert ts[1] == \
+        select_time_index_value(headers, notification).isoformat()
+
+
+def test_use_latest_meta_time_instant():
+    headers = {}
+    base_point = datetime(2019, 1, 1)
+
+    ts = build_notification_timepoints(base_point)
+    ts[1] = None  # time instant slot
+
+    notification = build_notification(*ts)
+
+    # latest meta time instant slot = 7
+    assert ts[7] == \
+        select_time_index_value(headers, notification).isoformat()
+
+
+def test_use_latest_meta_date_modified():
+    headers = {}
+    base_point = datetime(2019, 1, 1)
+
+    ts = build_notification_timepoints(base_point)
+    ts[1] = None  # time instant slot
+    ts[2] = None  # date modified
+    ts[3] = None  # meta time instant
+    ts[5] = None  # a1 time instant
+    ts[7] = None  # a2 time instant
+
+    notification = build_notification(*ts)
+
+    # latest meta date modified slot = 8
+    assert ts[8] == \
+        select_time_index_value(headers, notification).isoformat()
+
+
+def test_use_date_modified():
+    headers = {}
+    base_point = datetime(2019, 1, 1)
+
+    ts = build_notification_timepoints(base_point)
+    ts[1] = None  # time instant slot
+    ts[3] = None  # meta time instant
+    ts[5] = None  # a1 time instant
+    ts[7] = None  # a2 time instant
+
+    notification = build_notification(*ts)
+
+    # date modified slot = 2
+    assert ts[2] == \
+        select_time_index_value(headers, notification).isoformat()
+
+
+def test_use_default_value():
+    headers = {}
+    notification = build_notification(None, None, None, None, None, None, None,
+                                      None, None)
+
+    actual = select_time_index_value(headers, notification)
+    diff = datetime.now() - actual
+    assert diff < timedelta(seconds=2)

--- a/src/reporter/timex.py
+++ b/src/reporter/timex.py
@@ -57,6 +57,33 @@ def _iter_date_modified_in_metadata(notification: dict) \
 
 
 def select_time_index_value(headers: dict, notification: dict) -> datetime:
+    """
+    Determine which attribute or metadata value to use as a time index for the
+    entity being notified.
+    The returned value will be the first value found in the below list that can
+    be converted to a ``datetime``. Items are considered from top to bottom,
+    so that if multiple values are present and they can all be converted to
+    ``datetime``, the topmost value is chosen.
+
+    - Custom time index. The value of the ``TIME_INDEX_HEADER_NAME``. Note
+      that for a notification to contain such header, the corresponding
+      subscription has to be created with an ``httpCustom`` block as detailed
+      in the *Subscriptions* and *Custom Notifications* sections of the NGSI
+      spec.
+    - ``TimeInstant`` attribute.
+    - ``TimeInstant`` metadata. The most recent ``TimeInstant`` attribute value
+      found in any of the attribute metadata sections in the notification.
+    - ``dateModified`` attribute.
+    - ``dateModified`` metadata. The most recent ``dateModified`` attribute
+      value found in any of the attribute metadata sections in the notification.
+    - Current time. This is the default value we use if any of the above isn't
+      present or none of the values found can actually be converted to a
+      ``datetime``.
+
+    :param headers: the HTTP headers as received from Orion.
+    :param notification: the notification JSON payload as received from Orion.
+    :return: the value to be used as time index.
+    """
     custom_index = to_datetime(
                             _custom_time_index_attribute(headers, notification))
     time_instant = to_datetime(_time_instant_attribute(notification))
@@ -74,3 +101,11 @@ def select_time_index_value(headers: dict, notification: dict) -> datetime:
 
     return [d for d in priority_list if d][0]
     # Note. Index will never be out of bounds since we added a default value.
+
+
+def select_time_index_value_as_iso(headers: dict, notification: dict) -> str:
+    """
+    Same as ``select_time_index_value`` but formats the returned ``datetime``
+    as an ISO 8601 string.
+    """
+    return select_time_index_value(headers, notification).isoformat()

--- a/src/reporter/timex.py
+++ b/src/reporter/timex.py
@@ -1,0 +1,76 @@
+from datetime import datetime
+from typing import Iterable, Union
+
+from utils.common import iter_entity_attrs
+from utils.jsondict import maybe_value
+from utils.timestr import latest_from_str_rep, to_datetime
+
+TIME_INDEX_HEADER_NAME = 'Fiware-TimeIndex-Attribute'
+
+MaybeString = Union[str, None]
+
+
+def _first_not_none(xs: Iterable):
+    ys = [x for x in xs if x is not None]
+    return ys[0]
+# NB this function is always called with a sequence containing at least one
+# value != None.
+
+
+def _custom_time_index_attribute(headers: dict, notification: dict) \
+        -> MaybeString:
+    attr_name = maybe_value(headers, TIME_INDEX_HEADER_NAME)
+    if attr_name:
+        return maybe_value(notification, attr_name, 'value')
+    return None
+
+
+def _time_instant_attribute(notification: dict) -> MaybeString:
+    return maybe_value(notification, 'TimeInstant', 'value')
+
+
+def _meta_time_instant_attribute(notification: dict, attr_name: str) \
+        -> MaybeString:
+    return maybe_value(notification,
+                       attr_name, 'metadata', 'TimeInstant', 'value')
+
+
+def _date_modified_attribute(notification: dict) -> MaybeString:
+    return maybe_value(notification, 'dateModified', 'value')
+
+
+def _meta_date_modified_attribute(notification: dict, attr_name: str) \
+        -> MaybeString:
+    return maybe_value(notification,
+                       attr_name, 'metadata', 'dateModified', 'value')
+
+
+def _iter_time_instant_in_metadata(notification: dict) -> Iterable[MaybeString]:
+    for attr_name in iter_entity_attrs(notification):
+        yield _meta_time_instant_attribute(notification, attr_name)
+
+
+def _iter_date_modified_in_metadata(notification: dict) \
+        -> Iterable[MaybeString]:
+    for attr_name in iter_entity_attrs(notification):
+        yield _meta_date_modified_attribute(notification, attr_name)
+
+
+def select_time_index_value(headers: dict, notification: dict) -> datetime:
+    custom_index = to_datetime(
+                            _custom_time_index_attribute(headers, notification))
+    time_instant = to_datetime(_time_instant_attribute(notification))
+    meta_time_instant = latest_from_str_rep(
+                                _iter_time_instant_in_metadata(notification))
+    date_modified = to_datetime(_date_modified_attribute(notification))
+    meta_date_modified = latest_from_str_rep(
+                                _iter_date_modified_in_metadata(notification))
+    default_value = datetime.now()
+
+    priority_list = [
+        custom_index, time_instant, meta_time_instant, date_modified,
+        meta_date_modified, default_value
+    ]
+
+    return [d for d in priority_list if d][0]
+    # Note. Index will never be out of bounds since we added a default value.

--- a/src/utils/jsondict.py
+++ b/src/utils/jsondict.py
@@ -1,0 +1,84 @@
+"""
+This module provides utilities to work with JSON data represented as
+a Python dictionary tree.
+"""
+
+from typing import Iterable
+
+
+def safe_get_value(maybe_dict, key: str):
+    """
+    Get the value for `key` if `maybe_dict` is a `dict` and has that
+    key. If `key` isn't there return `None`. Otherwise, `maybe_dict`
+    isn't a `dict`, so return `maybe_dict` as is.
+    """
+    if isinstance(maybe_dict, dict):
+        return maybe_dict.get(key, None)
+    return maybe_dict
+
+
+def collect_values(tree: dict, *path_components: str) -> Iterable:
+    """
+    Collect values ``[v0, v1, ..]`` corresponding to key path ``[k1, k2, ..]``
+    on the input dictionary tree. The key sequence may match an actual key path
+    or match it up to a point or not match any path at all. If a key ``k[n]``
+    in the input sequence isn't in the tree, we set the corresponding value
+    ``v[n]`` to ``None``. Since ``k[n+1], k[n+2], ..`` won't be in the
+    tree either, ``v[n+1], k[n+2], ..`` will all be ``None`` too.
+
+    Examples:
+
+        >>> tree = {'h': {'k': {'j': 3}}}
+
+        >>> list(collect_values(tree, 'x'))
+        [None]
+
+        >>> list(collect_values(tree, 'h', 'k'))
+        [{'k': {'j': 3}}, {'j': 3}]
+
+        >>> list(collect_values(tree, 'h', 'k', 'j', 'x', 'y'))
+        [{'k': {'j': 3}}, {'j': 3}, 3, None, None]
+
+    :param tree: a tree of dictionaries: inner nodes are dictionaries while any
+        non-dictionary value is considered a leaf.
+    :param path_components: the key path ``[k1, k2, ..]``.
+    :return: an iterable containing the sequence ``v0, v1, ..``.
+    """
+    for key in path_components:
+        v = tree.get(key, None)
+        tree = v if isinstance(v, dict) else {}
+        yield v
+
+
+def maybe_value(tree: dict, *path_components: str):
+    """
+    Get the value corresponding to last key in the key path ``[k1, k2, ..]``
+    on the input dictionary tree. The key sequence may match an actual key path
+    or match it up to a point or not match any path at all. If a key ``k[n]``
+    in the input sequence isn't in the tree, we return ``None``.
+
+    Examples:
+
+        >>> tree = {'h': {'k': {'j': 3}}}
+
+        >>> maybe_value(tree, 'x') is None
+        True
+
+        >>> maybe_value(tree, 'h', 'k')
+        {'j': 3}
+
+        >>> maybe_value(tree, 'h', 'k', 'j')
+        3
+
+        >>> maybe_value(tree, 'h', 'k', 'j', 'x', 'y') is None
+        True
+
+    :param tree: a tree of dictionaries: inner nodes are dictionaries while any
+        non-dictionary value is considered a leaf.
+    :param path_components: the key path ``[k1, k2, ..]``.
+    :return: the value, if any, corresponding to the last key in the path.
+    """
+    if path_components:
+        vs = collect_values(tree, *path_components)
+        return list(vs)[len(path_components) - 1]
+    return None

--- a/src/utils/subscription_dsl.py
+++ b/src/utils/subscription_dsl.py
@@ -48,6 +48,19 @@ def url(value):
     return node('http', mforest(node('url', value)))
 
 
+def custom(notification_url, *children):
+    return node('httpCustom',
+                mforest(node('url', notification_url), *children))
+
+
+def headers(*children):
+    return node('headers', mforest(*children))
+
+
+def http_header(name, value):
+    return node(name, value)
+
+
 def metadata(value):
     return node('metadata', value)
 

--- a/src/utils/tests/test_jsondict.py
+++ b/src/utils/tests/test_jsondict.py
@@ -1,0 +1,45 @@
+import pytest
+from utils.jsondict import *
+
+
+@pytest.mark.parametrize('maybe_dict, key, expected', [
+    ({}, '', None), ({}, 'k', None),
+    (123, '', 123), (123, 'k', 123),
+    ({'h': 1}, '', None), ({'h': 1}, 'k', None),
+    ({'k': 1}, '', None), ({'k': 1}, 'k', 1)
+])
+def test_safe_get_value(maybe_dict, key, expected):
+    assert safe_get_value(maybe_dict, key) == expected
+
+
+@pytest.mark.parametrize('tree, path, expected', [
+    ({}, [], []), ({}, [''], [None]), ({}, ['h'], [None]),
+    ({}, ['h', 'k'], [None, None]),
+    ({'h': 1}, [], []), ({'h': 1}, [''], [None]), ({'h': 1}, ['h'], [1]),
+    ({'h': 1}, ['h', 'k'], [1, None]),
+    ({'h': {'k': 2}}, [], []), ({'h': {'k': 2}}, [''], [None]),
+    ({'h': {'k': 2}}, ['h'], [{'k': 2}]),
+    ({'h': {'k': 2}}, ['h', 'k'], [{'k': 2}, 2]),
+    ({'h': {'k': 2}}, ['h', 'k', 'j'], [{'k': 2}, 2, None]),
+    ({'h': {'k': {'j': 3}}}, ['h', 'k', 'j'],
+     [{'k': {'j': 3}}, {'j': 3}, 3])
+])
+def test_collect_values(tree, path, expected):
+    vs = collect_values(tree, *path)
+    assert expected == list(vs)
+
+
+@pytest.mark.parametrize('tree, path, expected', [
+    ({}, [], None), ({}, [''], None), ({}, ['h'], None),
+    ({}, ['h', 'k'], None),
+    ({'h': 1}, [], None), ({'h': 1}, [''], None), ({'h': 1}, ['h'], 1),
+    ({'h': 1}, ['h', 'k'], None),
+    ({'h': {'k': 2}}, [], None), ({'h': {'k': 2}}, [''], None),
+    ({'h': {'k': 2}}, ['h'], {'k': 2}),
+    ({'h': {'k': 2}}, ['h', 'k'], 2),
+    ({'h': {'k': 2}}, ['h', 'k', 'j'], None),
+    ({'h': {'k': {'j': 3}}}, ['h', 'k', 'j'], 3),
+    ({'h': {'k': {'j': 3}}}, ['h', 'k', 'j', 'x', 'y'], None)
+])
+def test_maybe_value(tree, path, expected):
+    assert expected == maybe_value(tree, *path)

--- a/src/utils/tests/test_timestr.py
+++ b/src/utils/tests/test_timestr.py
@@ -1,0 +1,41 @@
+import pytest
+from dateutil.tz import tzutc
+from utils.timestr import *
+
+
+# see: https://stackoverflow.com/questions/127803
+@pytest.mark.parametrize('string_rep, expected', [
+    (None, None), ('', None), (' ', None), ('\t', None), ('\n', None),
+    ('2008-09-03T20:56:35.450686Z',     # RFC 3339 format
+        datetime(2008, 9, 3, 20, 56, 35, 450686, tzinfo=tzutc())),
+    ('2008-09-03T20:56:35.450686',      # ISO 8601 extended format
+        datetime(2008, 9, 3, 20, 56, 35, 450686)),
+    ('20080903T205635.450686',          # ISO 8601 basic format
+        datetime(2008, 9, 3, 20, 56, 35, 450686)),
+    ('20080903',                        # ISO 8601 basic format, date only
+        datetime(2008, 9, 3, 0, 0))
+])
+def test_to_datetime(string_rep, expected):
+    assert expected == to_datetime(string_rep)
+
+
+@pytest.mark.parametrize('timepoints, expected', [
+    ([], None),
+    ([datetime(2019, 2, 1)], datetime(2019, 2, 1)),
+    ([datetime(2019, 2, 1), datetime(2018, 1, 1)], datetime(2019, 2, 1)),
+    ([datetime(2019, 1, 1), datetime(2019, 2, 1), datetime(2018, 1, 1)],
+     datetime(2019, 2, 1))
+])
+def test_latest(timepoints, expected):
+    assert expected == latest(timepoints)
+
+
+@pytest.mark.parametrize('str_reps, expected', [
+    ([], None), (['', None, ' '], None),
+    (['20190201', ''], datetime(2019, 2, 1)),
+    (['20190201', None, '20180101', 'xxx'], datetime(2019, 2, 1)),
+    (['20190101', '20190201', '20180101', None, ''],
+     datetime(2019, 2, 1))
+])
+def test_latest_from_str_rep(str_reps, expected):
+    assert expected == latest_from_str_rep(str_reps)

--- a/src/utils/timestr.py
+++ b/src/utils/timestr.py
@@ -1,0 +1,55 @@
+"""
+This module provides utilities to work with string representations of time
+points.
+"""
+
+from dateutil.parser import parse
+from datetime import datetime
+from typing import Iterable, Union
+
+MaybeString = Union[str, None]
+MaybeDateTime = Union[datetime, None]
+
+
+def to_datetime(rep: MaybeString) -> MaybeDateTime:
+    """
+    Convert a string representation of a time point to a ``datetime`` object
+    if possible, otherwise return ``None``.
+
+    :param rep: the string representation, typically in ISO 8601 format.
+    :return: the converted ``datetime`` or ``None`` if conversion fails.
+    """
+    if rep:
+        try:
+            return parse(rep)
+        except (ValueError, OverflowError):
+            return None
+    return None
+
+
+def latest(ds: Iterable[datetime]) -> MaybeDateTime:
+    """
+    Pick the most recent time point out of the input lot.
+
+    :param ds: the input time points.
+    :return: the most recent time point or ``None`` if the input stream is
+        empty.
+    """
+    xs = sorted(ds)
+    if xs:
+        return xs[-1]
+    return None
+
+
+def latest_from_str_rep(rs: Iterable[MaybeString]) -> MaybeDateTime:
+    """
+    Convert the input string representations to ``datetime`` objects and return
+    the latest.
+
+    :param rs: input time points in string format, typically ISO 8601.
+    :return: the latest time point if at least one string representation
+        could be converted or ``None`` otherwise.
+    """
+    xs = map(to_datetime, rs)
+    ys = filter(lambda x: x is not None, xs)
+    return latest(ys)


### PR DESCRIPTION
This PR implements a strategy to select a time index value from the notification payload and implements the features requested in #93.

### Selection strategy
We determine which attribute or metadata value to use as a time index for the entity being notified by selecting the first value found in the below list that can be converted to a `datetime`. Items are considered from top to bottom, so that if multiple values are present and they can all be converted to `datetime`, the topmost value is chosen.

1. Custom time index. The value of the `Fiware-TimeIndex-Attribute`. Note that for a notification to contain such header, the corresponding subscription has to be created with an `httpCustom` block as detailed in the *Subscriptions* and *Custom Notifications* sections of the [NGSI spec][ngsi-spec].
2. `TimeInstant` attribute. As specified in the Fiware [IoT agent documentation][time-instant].
3. `TimeInstant` metadata. The most recent `TimeInstant` attribute value found in any of the attribute metadata sections in the notification. (Again, refer to the [IoT agent documentation][time-instant].)
4. `dateModified` attribute.
5. `dateModified` metadata. The most recent `dateModified` attribute value found in any of the attribute metadata sections in the notification.
6. Current time. This is the default value we use if any of the above isn't present or none of the values found can actually be converted to a `datetime`.

### API extensions
Since *QuantumLeap* has a `subscribe` endpoint to set up NGSI subscriptions, we have extended it to support setting up a subscription where you can easily specify the time index to use in notifications: the time index attribute to use is simply passed in as an additional query parameter to the existing  `subscribe` endpoint and with that *QantumLeap* creates a custom NGSI subscription containing the `Fiware-TimeIndex-Attribute` as detailed earlier.

### Time representation considerations
Both `TimeInstant` and `dateModified` are supposed to contain timestamps represented in the ISO 8601 format. (See: [IoT agent documentation][time-instant] and `dateModified ` in the *Built-in Attributes* section of the [NGSI spec][ngsi-spec].) We have introduced timestamp validation so that *QantumLeap* will use a timestamp value as time index *only* if it actually is a valid ISO 8601 timestamp. This makes one of our regression tests (`test_index_with_millis`) fail since it uses notifications containing `dateModified` attributes whose values are expressed as milliseconds from the epoc as opposed to ISO 8601 timestamps. We have to decide if we should support this too or rather stick to the NGSI spec which only caters for ISO 8601 timestamps.



[ngsi-spec]: http://fiware.github.io/specifications/ngsiv2/stable/
[time-instant]: https://github.com/telefonicaid/iotagent-node-lib#the-timeinstant-element