### PR TITLE
Time_index enhancement (issue 172)

### DIFF
--- a/docs/manuals/user/index.md
+++ b/docs/manuals/user/index.md
@@ -211,11 +211,20 @@ subscription has to be created with an `httpCustom` block, as detailed in the
 This is the way you can instruct QL to use custom attributes of the
 notification payload to be taken as *time index* indicators.
 
-1. **TimeInstant** attribute. As specified in the [FIWARE IoT agent documentation](https://github.com/telefonicaid/iotagent-node-lib#the-timeinstant-element).
+1. Custom **time index** metadata. The most recent custom time index (the value of the `Fiware-TimeIndex-Attribute`)
+attribute value found in any of the attribute metadata sections in the notification.
+See the previous option about the details regarding subscriptions.
+
+1. **TimeInstant** attribute. As specified in the
+[FIWARE IoT agent documentation](https://github.com/telefonicaid/iotagent-node-lib#the-timeinstant-element).
 
 1. **TimeInstant** metadata. The most recent `TimeInstant` attribute value
 found in any of the attribute metadata sections in the notification.
 (Again, refer to the [FIWARE IoT agent documentation](https://github.com/telefonicaid/iotagent-node-lib#the-timeinstant-element).)
+
+1. **timestamp** attribute.
+
+1. **timestamp** metadata. The most recent `timestamp` attribute value found in any of the attribute metadata sections in the notification. As specified in the [FIWARE data models documentation](https://fiware-datamodels.readthedocs.io/en/latest/guidelines/index.html#dynamic-attributes).
 
 1. **dateModified** attribute. If you payed attention in the
 [Orion Subscription section](#orion-subscription), this is the `"dateModified"`

--- a/docs/manuals/user/index.md
+++ b/docs/manuals/user/index.md
@@ -224,7 +224,9 @@ found in any of the attribute metadata sections in the notification.
 
 1. **timestamp** attribute.
 
-1. **timestamp** metadata. The most recent `timestamp` attribute value found in any of the attribute metadata sections in the notification. As specified in the [FIWARE data models documentation](https://fiware-datamodels.readthedocs.io/en/latest/guidelines/index.html#dynamic-attributes).
+1. **timestamp** metadata. The most recent `timestamp` attribute value found in any of the attribute metadata sections
+in the notification. As specified in the
+[FIWARE data models documentation](https://fiware-datamodels.readthedocs.io/en/latest/guidelines/index.html#dynamic-attributes).
 
 1. **dateModified** attribute. If you payed attention in the
 [Orion Subscription section](#orion-subscription), this is the `"dateModified"`

--- a/src/reporter/subscription_builder.py
+++ b/src/reporter/subscription_builder.py
@@ -7,6 +7,10 @@ def build_subscription(quantumleap_url,
                        attributes, observed_attributes, notified_attributes,
                        throttling_secs,
                        time_index_attribute=None):
+    metadata_list = ['dateCreated', 'dateModified', 'TimeInstant', 'timestamp']
+    if time_index_attribute is not None:
+        metadata_list.append(time_index_attribute)
+
     tree = subscription(
         description('Created by QuantumLeap {}.'.format(quantumleap_url)),
         subject(
@@ -22,7 +26,7 @@ def build_subscription(quantumleap_url,
         ),
         notification(
             build_notification_target(quantumleap_url, time_index_attribute),
-            metadata(['dateCreated', 'dateModified', 'TimeInstant']),
+            metadata(metadata_list),
             attrs(first_of(attributes, notified_attributes))
         ),
         throttling(throttling_secs)

--- a/src/reporter/tests/test_subscribe.py
+++ b/src/reporter/tests/test_subscribe.py
@@ -43,7 +43,7 @@ def test_valid_defaults(clean_mongo, clean_crate):
         'attrs': [],
         'attrsFormat': 'normalized',
         'http': {'url': "{}/notify".format(QL_URL)},
-        'metadata': ['dateCreated', 'dateModified', 'TimeInstant'],
+        'metadata': ['dateCreated', 'dateModified', 'TimeInstant', 'timestamp']
     }
     assert subscription['throttling'] == 1
 
@@ -82,7 +82,7 @@ def test_valid_customs(clean_mongo, clean_crate):
         'attrs': ["pressure"],
         'attrsFormat': 'normalized',
         'http': {'url': "{}/notify".format(QL_URL)},
-        'metadata': ['dateCreated', 'dateModified', 'TimeInstant'],
+        'metadata': ['dateCreated', 'dateModified', 'TimeInstant', 'timestamp']
     }
     assert subscription['throttling'] == 30
 
@@ -155,5 +155,5 @@ def test_custom_time_index(clean_mongo, clean_crate):
                 TIME_INDEX_HEADER_NAME: 'my-time-index'
             }
         },
-        'metadata': ['dateCreated', 'dateModified', 'TimeInstant'],
+        'metadata': ['dateCreated', 'dateModified', 'TimeInstant', 'timestamp', 'my-time-index']
     }

--- a/src/reporter/tests/test_subscription_builder.py
+++ b/src/reporter/tests/test_subscription_builder.py
@@ -21,7 +21,7 @@ def test_bare_subscription():
             'http': {
                 'url': 'http://ql/notify'
             },
-            'metadata': ['dateCreated', 'dateModified', 'TimeInstant']
+            'metadata': ['dateCreated', 'dateModified', 'TimeInstant', 'timestamp']
         },
         'throttling': 1
     }
@@ -47,7 +47,7 @@ def test_entity_type():
             'http': {
                 'url': 'http://ql/notify'
             },
-            'metadata': ['dateCreated', 'dateModified', 'TimeInstant']
+            'metadata': ['dateCreated', 'dateModified', 'TimeInstant', 'timestamp']
         },
         'throttling': 1
     }
@@ -72,7 +72,7 @@ def test_entity_id():
             'http': {
                 'url': 'http://ql/notify'
             },
-            'metadata': ['dateCreated', 'dateModified', 'TimeInstant']
+            'metadata': ['dateCreated', 'dateModified', 'TimeInstant', 'timestamp']
         },
         'throttling': 1
     }
@@ -102,7 +102,7 @@ def test_attributes(attrs):
                 'url': 'http://ql/notify'
             },
             'attrs': attrs.split(','),
-            'metadata': ['dateCreated', 'dateModified', 'TimeInstant']
+            'metadata': ['dateCreated', 'dateModified', 'TimeInstant', 'timestamp']
         },
         'throttling': 1
     }
@@ -131,7 +131,7 @@ def test_observed_attributes(attrs):
             'http': {
                 'url': 'http://ql/notify'
             },
-            'metadata': ['dateCreated', 'dateModified', 'TimeInstant']
+            'metadata': ['dateCreated', 'dateModified', 'TimeInstant', 'timestamp']
         },
         'throttling': 1
     }
@@ -158,7 +158,7 @@ def test_notified_attributes(attrs):
                 'url': 'http://ql/notify'
             },
             'attrs': attrs.split(','),
-            'metadata': ['dateCreated', 'dateModified', 'TimeInstant']
+            'metadata': ['dateCreated', 'dateModified', 'TimeInstant', 'timestamp']
         },
         'throttling': 1
     }
@@ -183,7 +183,7 @@ def test_throttling():
             'http': {
                 'url': 'http://ql/notify'
             },
-            'metadata': ['dateCreated', 'dateModified', 'TimeInstant']
+            'metadata': ['dateCreated', 'dateModified', 'TimeInstant', 'timestamp']
         },
         'throttling': 123
     }
@@ -208,7 +208,7 @@ def test_entity_id_overrides_pattern():
             'http': {
                 'url': 'http://ql/notify'
             },
-            'metadata': ['dateCreated', 'dateModified', 'TimeInstant']
+            'metadata': ['dateCreated', 'dateModified', 'TimeInstant', 'timestamp']
         },
         'throttling': 1
     }
@@ -237,7 +237,7 @@ def test_all_attributes():
                 'url': 'http://ql/notify'
             },
             'attrs': ['b', 'c'],
-            'metadata': ['dateCreated', 'dateModified', 'TimeInstant']
+            'metadata': ['dateCreated', 'dateModified', 'TimeInstant', 'timestamp']
         },
         'throttling': 1
     }
@@ -271,7 +271,7 @@ def test_attributes_overrides_other_attributes(observed, notified):
                 'url': 'http://ql/notify'
             },
             'attrs': ['x'],
-            'metadata': ['dateCreated', 'dateModified', 'TimeInstant']
+            'metadata': ['dateCreated', 'dateModified', 'TimeInstant', 'timestamp']
         },
         'throttling': 1
     }
@@ -300,7 +300,7 @@ def test_subscription_with_time_index():
                     TIME_INDEX_HEADER_NAME: 'my-time-index-attr-name'
                 }
             },
-            'metadata': ['dateCreated', 'dateModified', 'TimeInstant']
+            'metadata': ['dateCreated', 'dateModified', 'TimeInstant', 'timestamp', 'my-time-index-attr-name']
         },
         'throttling': 1
     }

--- a/src/reporter/tests/test_timex.py
+++ b/src/reporter/tests/test_timex.py
@@ -2,7 +2,9 @@ from datetime import *
 from reporter.timex import *
 
 
-def build_notification(custom, ti, dm, mti, mdm, a1_ti, a1_dm, a2_ti, a2_dm):
+def build_notification(custom, ti, ts, dm,
+                       a1_custom, a1_ti, a1_ts, a1_dm,
+                       a2_custom, a2_ti, a2_ts, a2_dm):
     return {
         'customTimeIndex': {
             'value': custom
@@ -10,21 +12,22 @@ def build_notification(custom, ti, dm, mti, mdm, a1_ti, a1_dm, a2_ti, a2_dm):
         'TimeInstant': {
             'value': ti
         },
+        'timestamp': {
+            'value': ts
+        },
         'dateModified': {
             'value': dm
         },
-        'metadata': {
-            'TimeInstant': {
-                'value': mti
-            },
-            'dateModified': {
-                'value': mdm
-            }
-        },
         'a1': {
             'metadata': {
+                'customTimeIndex': {
+                    'value': a1_custom
+                },
                 'TimeInstant': {
                     'value': a1_ti
+                },
+                'timestamp': {
+                    'value': a1_ts
                 },
                 'dateModified': {
                     'value': a1_dm
@@ -33,8 +36,14 @@ def build_notification(custom, ti, dm, mti, mdm, a1_ti, a1_dm, a2_ti, a2_dm):
         },
         'a2': {
             'metadata': {
+                'customTimeIndex': {
+                    'value': a2_custom
+                },
                 'TimeInstant': {
                     'value': a2_ti
+                },
+                'timestamp': {
+                    'value': a2_ts
                 },
                 'dateModified': {
                     'value': a2_dm
@@ -46,7 +55,7 @@ def build_notification(custom, ti, dm, mti, mdm, a1_ti, a1_dm, a2_ti, a2_dm):
 
 def build_notification_timepoints(base_point):
     ts = []
-    for k in range(9):
+    for k in range(12):
         d = base_point + timedelta(days=k)
         ts.append(d.isoformat())
     return ts
@@ -64,6 +73,22 @@ def test_custom_index_takes_priority():
         select_time_index_value(headers, notification)
 
 
+def test_use_latest_meta_custom_index():
+    headers = {
+        TIME_INDEX_HEADER_NAME: 'customTimeIndex'
+    }
+    base_point = datetime(2019, 1, 1)
+
+    ts = build_notification_timepoints(base_point)
+    ts[0] = None  # custom index attribute slot
+
+    notification = build_notification(*ts)
+
+    # latest meta custom index slot = 8
+    assert ts[8] == \
+        select_time_index_value(headers, notification).isoformat()
+
+
 def test_skip_custom_index_if_it_has_no_value():
     headers = {
         TIME_INDEX_HEADER_NAME: 'customTimeIndex'
@@ -71,6 +96,8 @@ def test_skip_custom_index_if_it_has_no_value():
     base_point = datetime(2019, 1, 1)
     ts = build_notification_timepoints(base_point)
     ts[0] = None  # custom index slot
+    ts[4] = None  # custom index metadata for a1
+    ts[8] = None  # custom index metadata for a2
     notification = build_notification(*ts)
 
     assert ts[1] == \
@@ -96,26 +123,38 @@ def test_use_latest_meta_time_instant():
 
     notification = build_notification(*ts)
 
-    # latest meta time instant slot = 7
-    assert ts[7] == \
+    # latest meta time instant slot = 9
+    assert ts[9] == \
         select_time_index_value(headers, notification).isoformat()
 
 
-def test_use_latest_meta_date_modified():
+def test_use_timestamp():
+    headers = {}
+    base_point = datetime(2019, 1, 1)
+    ts = build_notification_timepoints(base_point)
+    ts[1] = None  # TimeInstant slot
+    ts[5] = None  # TimeInstant metadata for a1
+    ts[9] = None  # TimeInstant metadata for a2
+    notification = build_notification(*ts)
+
+    assert ts[2] == \
+        select_time_index_value(headers, notification).isoformat()
+
+
+def test_use_latest_meta_timestamp():
     headers = {}
     base_point = datetime(2019, 1, 1)
 
     ts = build_notification_timepoints(base_point)
-    ts[1] = None  # time instant slot
-    ts[2] = None  # date modified
-    ts[3] = None  # meta time instant
-    ts[5] = None  # a1 time instant
-    ts[7] = None  # a2 time instant
+    ts[1] = None  # TimeInstant slot
+    ts[2] = None  # timestamp slot
+    ts[5] = None  # TimeInstant metadata for a1
+    ts[9] = None  # TimeInstant metadata for a2
 
     notification = build_notification(*ts)
 
-    # latest meta date modified slot = 8
-    assert ts[8] == \
+    # latest meta time instant slot = 10
+    assert ts[10] == \
         select_time_index_value(headers, notification).isoformat()
 
 
@@ -125,21 +164,42 @@ def test_use_date_modified():
 
     ts = build_notification_timepoints(base_point)
     ts[1] = None  # time instant slot
-    ts[3] = None  # meta time instant
+    ts[2] = None  # timestamp slot
     ts[5] = None  # a1 time instant
-    ts[7] = None  # a2 time instant
+    ts[6] = None  # a1 timestamp
+    ts[9] = None  # a2 time instant
+    ts[10] = None  # a2 timestamp
 
     notification = build_notification(*ts)
 
-    # date modified slot = 2
-    assert ts[2] == \
+    # date modified slot = 3
+    assert ts[3] == \
+        select_time_index_value(headers, notification).isoformat()
+
+
+def test_use_latest_meta_date_modified():
+    headers = {}
+    base_point = datetime(2019, 1, 1)
+
+    ts = build_notification_timepoints(base_point)
+    ts[1] = None  # time instant slot
+    ts[2] = None  # timestamp slot
+    ts[3] = None  # date modified slot
+    ts[5] = None  # a1 time instant
+    ts[6] = None  # a1 timestamp
+    ts[9] = None  # a2 time instant
+    ts[10] = None  # a2 timestamp
+
+    notification = build_notification(*ts)
+
+    # latest meta date modified slot = 11
+    assert ts[11] == \
         select_time_index_value(headers, notification).isoformat()
 
 
 def test_use_default_value():
     headers = {}
-    notification = build_notification(None, None, None, None, None, None, None,
-                                      None, None)
+    notification = build_notification(*([None] * 12))
 
     actual = select_time_index_value(headers, notification)
     diff = datetime.now() - actual

--- a/src/reporter/timex.py
+++ b/src/reporter/timex.py
@@ -46,7 +46,7 @@ def select_time_index_value(headers: dict, notification: dict) -> datetime:
       subscription has to be created with an ``httpCustom`` block as detailed
       in the *Subscriptions* and *Custom Notifications* sections of the NGSI
       spec.
-    - Custom time inde metadata. The most recent custom time index attribute value
+    - Custom time index metadata. The most recent custom time index attribute value
       found in any of the attribute metadata sections in the notification.
     - ``TimeInstant`` attribute.
     - ``TimeInstant`` metadata. The most recent ``TimeInstant`` attribute value
@@ -65,6 +65,8 @@ def select_time_index_value(headers: dict, notification: dict) -> datetime:
     :param notification: the notification JSON payload as received from Orion.
     :return: the value to be used as time index.
     """
+    current_time = datetime.now()
+
     considered_attributes = [
         maybe_value(headers, TIME_INDEX_HEADER_NAME),
         "TimeInstant",
@@ -76,16 +78,18 @@ def select_time_index_value(headers: dict, notification: dict) -> datetime:
         if not attr_name:
             continue
 
+        # check for the attribute <attr_name>
         attr_value = to_datetime(_attribute(notification, attr_name))
         if attr_value:
             return attr_value
 
+        # check for the latest meta attribute <attr_name>
         meta_value = latest_from_str_rep(
             _iter_metadata(notification, attr_name))
         if meta_value:
             return meta_value
 
-    return datetime.now()
+    return current_time
 
 
 def select_time_index_value_as_iso(headers: dict, notification: dict) -> str:


### PR DESCRIPTION
Updated <code>time_index</code> selection with three new steps (2, 5 and 6):

### Selection strategy

We determine which attribute or metadata value to use as a time index for the entity being notified by selecting the first value found in the below list that can be converted to a datetime. Items are considered from top to bottom, so that if multiple values are present and they can all be converted to datetime, the topmost value is chosen.

1. Custom time index. The value of the <code>Fiware-TimeIndex-Attribute</code>. Note that for a notification to contain such header, the corresponding subscription has to be created with an httpCustom block as detailed in the Subscriptions and Custom Notifications sections of the [NGSI spec](http://fiware.github.io/specifications/ngsiv2/stable/).
2. Custom time index metadata. The most recent custom time index (the value of the <code>Fiware-TimeIndex-Attribute</code>) attribute value found in any of the attribute metadata sections in the notification.
3. <code>TimeInstant</code> attribute. As specified in the Fiware [IoT agent documentation](https://github.com/telefonicaid/iotagent-node-lib#the-timeinstant-element).
4. <code>TimeInstant</code> metadata. The most recent <code>TimeInstant</code> attribute value found in any of the attribute metadata sections in the notification. (Again, refer to the [IoT agent documentation](https://github.com/telefonicaid/iotagent-node-lib#the-timeinstant-element).)
5. <code>timestamp</code> attribute.
6. <code>timestamp</code> metadata. The most recent <code>timestamp</code> attribute value found in any of the attribute metadata sections in the notification. As specified in the Fiware [data models documentation](https://fiware-datamodels.readthedocs.io/en/latest/guidelines/index.html#dynamic-attributes).
7. <code>dateModified</code> attribute.
8. <code>dateModified</code> metadata. The most recent <code>dateModified</code> attribute value found in any of the attribute metadata sections in the notification.
9. Current time. This is the default value we use if any of the above isn't present or none of the values found can actually be converted to a datetime.
