### PR TITLE
Add support for multiple data elements in notifications

### DIFF
--- a/src/conftest.py
+++ b/src/conftest.py
@@ -147,6 +147,53 @@ def entity():
     }
     return entity
 
+@pytest.fixture
+def sameTypeEntitiesWithDifferentAttrs():
+    """
+    Two updates for the same entity with different attributes.
+    The first update has temperature and pressure but the second update has only temperature.
+    """
+    entities = [
+        {
+            'id': 'Room1',
+            'type': 'Room',
+            'temperature': {
+                'value': 24.2,
+                'type': 'Number',
+                'metadata': {
+                    'dateModified': {
+                        'type': 'DateTime',
+                        'value': '2019-05-09T15:28:30.000'
+                    }
+                }
+            },
+            'pressure': {
+                'value': 720,
+                'type': 'Number',
+                'metadata': {
+                    'dateModified': {
+                        'type': 'DateTime',
+                        'value': '2019-05-09T15:28:30.000'
+                    }
+                }
+            }
+        },
+        {
+            'id': 'Room1',
+            'type': 'Room',
+            'temperature': {
+                'value': 25.2,
+                'type': 'Number',
+                'metadata': {
+                    'dateModified': {
+                        'type': 'DateTime',
+                        'value': '2019-05-09T15:29:30.000'
+                    }
+                }
+            }
+        }
+    ]
+    return entities
 
 @pytest.fixture
 def air_quality_observed():

--- a/src/conftest.py
+++ b/src/conftest.py
@@ -148,7 +148,7 @@ def entity():
     return entity
 
 @pytest.fixture
-def sameTypeEntitiesWithDifferentAttrs():
+def sameEntityWithDifferentAttrs():
     """
     Two updates for the same entity with different attributes.
     The first update has temperature and pressure but the second update has only temperature.

--- a/src/reporter/tests/test_notify.py
+++ b/src/reporter/tests/test_notify.py
@@ -215,27 +215,16 @@ def test_geocoding(notification, clean_mongo, crate_translator):
     assert float(lat) == pytest.approx(24.9412167, abs=1e-2)
 
 
-def test_no_multiple_data_elements(notification, clean_mongo, clean_crate):
-    second_element = {
-                        'id': 'Room2',
-                        'type': 'Room',
-                        'temperature': {
-                            'type': 'Number',
-                            'value': 30,
-                            'metadata': {
-                                'dateModified': {
-                                    'type': 'DateTime',
-                                    'value': '2017-06-20T11:46:45.00Z'
-                                }
-                            }
-                        }
-                    }
-    notification['data'].append(second_element)
+def test_multiple_data_elements(notification, sameTypeEntitiesWithDifferentAttrs, clean_mongo, clean_crate):
+    """
+    Test that the notify API can process notifications containing multiple elements in the data array.
+    """
+    notification['data'] = sameTypeEntitiesWithDifferentAttrs
+    print(json.dumps(notification))
     r = requests.post('{}'.format(notify_url), data=json.dumps(notification),
                       headers=HEADERS_PUT)
-    assert r.status_code == 400
-    assert r.json() == 'Multiple data elements in notifications not ' \
-                       'supported yet'
+    assert r.status_code == 200
+    assert r.json() == 'Notification successfully processed'
 
 
 def test_time_index(notification, clean_mongo, crate_translator):

--- a/src/reporter/tests/test_notify.py
+++ b/src/reporter/tests/test_notify.py
@@ -220,7 +220,6 @@ def test_multiple_data_elements(notification, sameEntityWithDifferentAttrs, clea
     Test that the notify API can process notifications containing multiple elements in the data array.
     """
     notification['data'] = sameEntityWithDifferentAttrs
-    print(json.dumps(notification))
     r = requests.post('{}'.format(notify_url), data=json.dumps(notification),
                       headers=HEADERS_PUT)
     assert r.status_code == 200

--- a/src/reporter/tests/test_notify.py
+++ b/src/reporter/tests/test_notify.py
@@ -215,11 +215,11 @@ def test_geocoding(notification, clean_mongo, crate_translator):
     assert float(lat) == pytest.approx(24.9412167, abs=1e-2)
 
 
-def test_multiple_data_elements(notification, sameTypeEntitiesWithDifferentAttrs, clean_mongo, clean_crate):
+def test_multiple_data_elements(notification, sameEntityWithDifferentAttrs, clean_mongo, clean_crate):
     """
     Test that the notify API can process notifications containing multiple elements in the data array.
     """
-    notification['data'] = sameTypeEntitiesWithDifferentAttrs
+    notification['data'] = sameEntityWithDifferentAttrs
     print(json.dumps(notification))
     r = requests.post('{}'.format(notify_url), data=json.dumps(notification),
                       headers=HEADERS_PUT)

--- a/src/translators/crate.py
+++ b/src/translators/crate.py
@@ -313,10 +313,9 @@ class CrateTranslator(base_translator.BaseTranslator):
                         values.append([float(lon), float(lat)])
                     else:
                         values.append(e[cn]['value'])
-                except KeyError as e:
-                    msg = ("Seems like not all entities of same type came "
-                           "with the same set of attributes. {}").format(e)
-                    raise NotImplementedError(msg)
+                except KeyError:
+                    # this entity update does not have a value for the column so use None which will be inserted as NULL to the db.
+                    values.append( None )
         return values
 
 

--- a/src/translators/tests/test_crate.py
+++ b/src/translators/tests/test_crate.py
@@ -29,6 +29,21 @@ def test_insert_entity(translator, entity):
 
     check_notifications_record([entity], loaded_entities)
 
+def test_insert_same_type_entities_with_different_attrs( translator, sameTypeEntitiesWithDifferentAttrs ):
+    """
+    Test that the CrateTranslator can insert entity updates  that are of the same type but have different attributes.
+    """
+    # Add time index to the updates. Use the dateModified meta data attribute of temperature.
+    for entity in sameTypeEntitiesWithDifferentAttrs:
+        entity[BaseTranslator.TIME_INDEX_NAME] = entity['temperature']['metadata']['dateModified']['value']
+        
+    result = translator.insert( sameTypeEntitiesWithDifferentAttrs )
+    assert result.rowcount != 0
+    
+    loaded_entities = translator.query()
+    assert len(loaded_entities) == 1
+
+    check_notifications_record( sameTypeEntitiesWithDifferentAttrs, loaded_entities)
 
 def test_insert_multiple_types(translator):
     args = {

--- a/src/translators/tests/test_crate.py
+++ b/src/translators/tests/test_crate.py
@@ -29,21 +29,21 @@ def test_insert_entity(translator, entity):
 
     check_notifications_record([entity], loaded_entities)
 
-def test_insert_same_type_entities_with_different_attrs( translator, sameTypeEntitiesWithDifferentAttrs ):
+def test_insert_same_entity_with_different_attrs( translator, sameEntityWithDifferentAttrs ):
     """
     Test that the CrateTranslator can insert entity updates  that are of the same type but have different attributes.
     """
     # Add time index to the updates. Use the dateModified meta data attribute of temperature.
-    for entity in sameTypeEntitiesWithDifferentAttrs:
+    for entity in sameEntityWithDifferentAttrs:
         entity[BaseTranslator.TIME_INDEX_NAME] = entity['temperature']['metadata']['dateModified']['value']
         
-    result = translator.insert( sameTypeEntitiesWithDifferentAttrs )
+    result = translator.insert( sameEntityWithDifferentAttrs )
     assert result.rowcount != 0
     
     loaded_entities = translator.query()
     assert len(loaded_entities) == 1
 
-    check_notifications_record( sameTypeEntitiesWithDifferentAttrs, loaded_entities)
+    check_notifications_record( sameEntityWithDifferentAttrs, loaded_entities)
 
 def test_insert_multiple_types(translator):
     args = {

--- a/src/utils/common.py
+++ b/src/utils/common.py
@@ -236,7 +236,7 @@ def check_notifications_record(notifications, records):
         r_values = record[a]['values']
         # collect values for the attribute a from the entities in the notification
         # if an entity does not have a value for the attribute use None
-        n_values = [e.get( a, { 'value': None } )['value'] for e in notifications]
+        n_values = [e[a]['value'] if a in e else None for e in notifications]
 
         if any(isinstance(x, float) for x in n_values):
             assert pytest.approx(r_values, n_values)

--- a/src/utils/common.py
+++ b/src/utils/common.py
@@ -234,7 +234,9 @@ def check_notifications_record(notifications, records):
             continue
 
         r_values = record[a]['values']
-        n_values = [e[a]['value'] for e in notifications]
+        # collect values for the attribute a from the entities in the notification
+        # if an entity does not have a value for the attribute use None
+        n_values = [e.get( a, { 'value': None } )['value'] for e in notifications]
 
         if any(isinstance(x, float) for x in n_values):
             assert pytest.approx(r_values, n_values)


### PR DESCRIPTION
The notify API can now process notifications whose data array contains more than one element.
Previously it returned an error message with the HTTP status 400.
reporter.reporter.notify method now loops through each data element
performing the operations previously done to the single element such as adding the time index and validating.
translators.crate.CrateTranslator._preprocess_values method now adds None to the values list if an entity update doesnot have a value for a given attribute.
Before it threw a KeyError exception. This allows _insert_entities_of_type to successfully insert
entities that have different attributes.

Tests were modified to test for this new feature:
- Test data was added to conftest
- test_notify.test_no_multiple_data_elements was renamed and modified to test the notify API with the test data.
- test_insert_same_type_entities_with_different_attrs test was added to test_crate.
   It uses the test data to check that the above described modification to CrateTranslator works.
- Utils.common.check_notifications_record method was modified to use None if there is no value for an attribute in an entity update.
  This was required for the method to work in the test_insert_same_type_entities_with_different_attrs test.

This pull request solves issue #185 