### PR TITLE
Support for NGSI_GEOPOINT for null values

### DIFF
--- a/src/translators/crate.py
+++ b/src/translators/crate.py
@@ -766,8 +766,9 @@ class CrateTranslator(base_translator.BaseTranslator):
 
                 # CrateDBs and NGSI use different geo:point coordinates order.
                 if original_type == NGSI_GEOPOINT:
-                    lon, lat = v
-                    v = "{}, {}".format(lat, lon)
+                    if v is not None:
+                        lon, lat = v
+                        v = "{}, {}".format(lat, lon)
 
                 if original_name in (NGSI_TYPE, NGSI_ID):
                     e[original_name] = v


### PR DESCRIPTION
While executing API {ql_ip}:{ql_port}/v2/entities/{entity_id} to get all attributes of the entity having **"null"** values for the attribute of type **"geo:point"** an error is shown as follows: 
**"Something went wrong with QL. Error: 'NoneType' object is not iterable"**.

After investigation, I have found that this error occurs because of the code which insert value of longitude and latitude with the None value.

To remove this error, I have added a check for the None value when type is NGSI_GEOPOINT.