### PR TITLE
Fix GH #206

### DIFF
--- a/src/reporter/query_1T1E1A.py
+++ b/src/reporter/query_1T1E1A.py
@@ -4,6 +4,7 @@ from reporter.reporter import _validate_query_params
 from translators.crate import CrateTranslatorInstance
 import logging
 from .geo_query_handler import handle_geo_query
+from utils.dicts import lookup_string_match
 
 
 def query_1T1E1A(attr_name,   # In Path
@@ -70,12 +71,13 @@ def query_1T1E1A(attr_name,   # In Path
             warnings.warn("Not expecting more than one result for a 1T1E1A.")
 
         index = [] if aggr_method and not aggr_period else entities[0]['index']
+        matched_attr = lookup_string_match(entities[0], attr_name)
         res = {
             'data': {
                 'entityId': entities[0]['id'],
                 'attrName': attr_name,
                 'index': index,
-                'values': entities[0][attr_name]['values']
+                'values': matched_attr['values']
             }
         }
         return res

--- a/src/reporter/query_1T1E1A.py
+++ b/src/reporter/query_1T1E1A.py
@@ -77,7 +77,7 @@ def query_1T1E1A(attr_name,   # In Path
                 'entityId': entities[0]['id'],
                 'attrName': attr_name,
                 'index': index,
-                'values': matched_attr['values']
+                'values': matched_attr['values'] if matched_attr else []
             }
         }
         return res

--- a/src/reporter/query_1TNE1A.py
+++ b/src/reporter/query_1TNE1A.py
@@ -4,6 +4,7 @@ from reporter.reporter import _validate_query_params
 from translators.crate import CrateTranslatorInstance, CrateTranslator
 import logging
 from .geo_query_handler import handle_geo_query
+from utils.dicts import lookup_string_match
 
 
 def query_1TNE1A(attr_name,   # In Path
@@ -94,7 +95,8 @@ def _prepare_response(entities, attr_name, entity_type, entity_ids,
                       aggr_method, aggr_period, from_date, to_date):
     values = {}
     for e in entities:
-        values[e['id']] = e[attr_name]['values']
+        matched_attr = lookup_string_match(e, attr_name)
+        values[e['id']] = matched_attr['values'] if matched_attr else []
 
     if aggr_method and not aggr_period:
         # Use fromDate / toDate

--- a/src/reporter/tests/test_attribute_name_case.py
+++ b/src/reporter/tests/test_attribute_name_case.py
@@ -1,0 +1,59 @@
+from conftest import QL_URL
+import pytest
+import requests
+import time
+import urllib
+from .utils import send_notifications
+
+
+attr1 = 'AtTr1'
+attr2 = 'aTtr_2'
+
+
+def mk_entity(eid):
+    return {
+        'id': eid,
+        'type': 'TestDevice',
+        attr1: {
+            'type': 'Text',
+            'value': '1'
+        },
+        attr2: {
+            'type': 'Number',
+            'value': 2
+        }
+    }
+
+
+def insert_entities(entities):
+    notification_data = [{'data': entities}]
+    send_notifications(notification_data)
+
+    time.sleep(2)
+
+
+def query_1t1e1a(entity_id, attr_name):
+    escaped_attr_name = urllib.parse.quote(attr_name)
+    url = "{}/entities/{}/attrs/{}".format(QL_URL, entity_id, escaped_attr_name)
+    response = requests.get(url)
+    assert response.status_code == 200
+    return response.json().get('data', {})
+
+
+@pytest.mark.parametrize('attr_name', [
+    attr1, 'attr1', 'atTr1'
+])
+def test_1t1e1a(attr_name, clean_crate):
+    entity = mk_entity('d1')
+
+    insert_entities([entity])
+
+    query_result = query_1t1e1a(entity['id'], attr_name)
+    query_result.pop('index', None)
+    assert query_result == {
+        'attrName': attr_name,
+        'entityId': entity['id'],
+        'values': [entity[attr1]['value']]
+    }
+
+

--- a/src/translators/crate.py
+++ b/src/translators/crate.py
@@ -633,7 +633,8 @@ class CrateTranslator(base_translator.BaseTranslator):
         if entity_id:
             entity_ids = tuple([entity_id])
 
-        select_clause = self._get_select_clause(attr_names,
+        lower_attr_names = [a.lower() for a in attr_names]
+        select_clause = self._get_select_clause(lower_attr_names,
                                                 aggr_method,
                                                 aggr_period)
         if not where_clause:

--- a/src/translators/crate.py
+++ b/src/translators/crate.py
@@ -633,7 +633,8 @@ class CrateTranslator(base_translator.BaseTranslator):
         if entity_id:
             entity_ids = tuple([entity_id])
 
-        lower_attr_names = [a.lower() for a in attr_names]
+        lower_attr_names = [a.lower() for a in attr_names]\
+            if attr_names else attr_names
         select_clause = self._get_select_clause(lower_attr_names,
                                                 aggr_method,
                                                 aggr_period)

--- a/src/utils/dicts.py
+++ b/src/utils/dicts.py
@@ -1,0 +1,27 @@
+"""
+This module provides utilities to work with dictionaries.
+"""
+
+
+def lookup_string_match(ds: dict, key):
+    """
+    Return the first value whose key matches the input key.
+    To this function, a matching dictionary key `k` is one
+    for which `m(k) = m(key)` where `m` is the function that
+    converts a value to a string and then lowercases that
+    string.
+    Also, to clarify further, "first" refers to the first
+    match found iterating the dictionary keys.
+
+    :param ds: the data.
+    :param key: the key for which to find a match.
+    :return: the dictionary value of a matched key if one is
+        found, `None` otherwise. Also return `None` when either
+        or both input params are `None`.
+    """
+    if ds is not None and key is not None:
+        key_to_match = str(key).lower()
+        for k in ds.keys():
+            if str(k).lower() == key_to_match:
+                return ds[k]
+    return None

--- a/src/utils/dicts.py
+++ b/src/utils/dicts.py
@@ -6,18 +6,33 @@ This module provides utilities to work with dictionaries.
 def lookup_string_match(ds: dict, key):
     """
     Return the first value whose key matches the input key.
-    To this function, a matching dictionary key `k` is one
-    for which `m(k) = m(key)` where `m` is the function that
-    converts a value to a string and then lowercases that
-    string.
-    Also, to clarify further, "first" refers to the first
-    match found iterating the dictionary keys.
+    To this function, a matching dictionary key ``k`` is one for which
+    ``m(k) = m(key)`` where ``m`` is the function that converts a value
+    to a string and then lowercases that string.
+    Also, to clarify further, "first" refers to the first match found
+    iterating the dictionary keys.
+
+    Examples:
+
+        >>> ds = {'kEy1': 'v1', 2: 'v2', 'key1': 'v3'}
+
+        >>> lookup_string_match(ds, 'key1')
+        'v1'
+
+        >>> lookup_string_match(ds, 'Key1')
+        'v1'
+
+        >>> lookup_string_match(ds, '2')
+        'v2'
+
+        >>> lookup_string_match(ds, 2)
+        'v2'
 
     :param ds: the data.
     :param key: the key for which to find a match.
-    :return: the dictionary value of a matched key if one is
-        found, `None` otherwise. Also return `None` when either
-        or both input params are `None`.
+    :return: the dictionary value of a matched key if one is found, ``None``
+        otherwise. Also return ``None`` when either or both input params are
+        ``None``.
     """
     if ds is not None and key is not None:
         key_to_match = str(key).lower()

--- a/src/utils/tests/test_dicts.py
+++ b/src/utils/tests/test_dicts.py
@@ -1,0 +1,29 @@
+import pytest
+from utils.dicts import *
+
+
+@pytest.mark.parametrize('ds, key', [
+    ({}, None), (None, ''), (None, None)
+])
+def test_lookup_string_match_with_none_args(ds, key):
+    assert lookup_string_match(ds, key) is None
+
+
+@pytest.mark.parametrize('ds, key', [
+    ({}, None), ({}, ''), ({}, 'k')
+])
+def test_lookup_string_match_with_empty_dict(ds, key):
+    assert lookup_string_match(ds, key) is None
+
+
+@pytest.mark.parametrize('key', [
+    'key', 'Key', 'KEy', 'KEY', 'kEy', 'kEY', 'keY'
+])
+def test_lookup_string_match_with_string_key(key):
+    ds = {1: 'a', 'kEy': 'b'}
+    assert lookup_string_match(ds, key) == 'b'
+
+
+def test_lookup_string_match_with_int_key():
+    ds = {1: 'a', 'kEy': 'b'}
+    assert lookup_string_match(ds, 1) == 'a'


### PR DESCRIPTION
This PR is a fix for #206.

### Notes

#### Attribute names
Call `AN` the set of all valid attribute names and consider the following equivalence relation on `AN`

    x ~ y  ⟺  lower(x) = lower(y)

where `lower` is the function that converts a string to lowercase. Quantum Leap identifies an entity attribute named `x` with the corresponding equivalence class `[x]` when storing and querying the data. In detail: when an attribute named `x` gets stored for the first time, Quantum Leap stores its value in a column named `y = lower(x)` as well as the metadata pair `(original name, column name) = (x, y)`. When querying `x` attribute values, you can then specify any member of `[x]` as attribute name in the query parameters or URL. This has the obvious downside that if an entity in JSON format contains two equivalent attributes (e.g. `airQualityIndex` and `airqualityindex`) which one gets stored is anyone's guess. Philosophers will be debating for years to come whether this is a Good or Bad Thing. But for the time being, we content ourselves with this fix.

#### Maintainability
Right now we have the lowercasing of attribute names scattered around the reporter queries and the Crate translator. Not good! Ideally we should encode our assumptions about attribute names using a type so that it's in just one place and easily unit-testable. Anyway, we'll probably have to refactor the Crate translator heavily going forward, so this can wait.