### PR TITLE
Flatten JSON in query results

### DIFF
--- a/specification/quantumleap.yml
+++ b/specification/quantumleap.yml
@@ -83,8 +83,6 @@ definitions:
 
   ValuesArray:
     type: array
-    items:
-      type: number
     description: "Array of values of the selected attribute, in the same
     corresponding order of the 'index' array. When using aggregation options,
     the format of this remains the same, only the semantics will change. For
@@ -663,28 +661,23 @@ paths:
           schema:
             type: object
             properties:
-              data:
-                type: object
-                properties:
-                  entityId:
-                    type: string
-                  attrName:
-                    type: string
-                  index:
-                    $ref: '#/definitions/IndexArray'
-                  values:
-                    $ref: '#/definitions/ValuesArray'
+              entityId:
+                type: string
+              attrName:
+                type: string
+              index:
+                $ref: '#/definitions/IndexArray'
+              values:
+                $ref: '#/definitions/ValuesArray'
           examples:
             application/json:
               {
-                "data": {
                     "entityId": "Kitchen1",
                     "attrName": "temperature",
                     "index": ["2018-01-05T15:44:34", "2018-01-06T15:44:59",
                     "2018-01-07T15:44:59"],
                     # TODO: in NGSI orion would return the type+metadata of attr
                     "values": [24.1, 25.3, 26.7]
-                  }
               }
         404:
           description: "Not Found"
@@ -735,18 +728,13 @@ paths:
         200:
           description: OK
           schema:
-            type: object
-            properties:
-              data:
-                $ref: '#/definitions/IndexedValues'
+            $ref: '#/definitions/IndexedValues'
           examples:
             application/json:
               {
-                "data": {
                     "index": ["2018-01-05T15:44:34", "2018-01-06T15:44:59",
                     "2018-01-07T15:44:59"],
                     "values": [24.1, 25.3, 26.7]
-                  }
               }
         404:
           description: "Not Found"
@@ -798,21 +786,17 @@ paths:
           schema:
             type: object
             properties:
-              data:
-                type: object
-                properties:
-                  entityId:
-                    type: string
-                  index:
-                    $ref: '#/definitions/IndexArray'
-                  attributes:
-                    type: array
-                    items:
-                      $ref: '#/definitions/AttributeValues'
+              entityId:
+                type: string
+              index:
+                $ref: '#/definitions/IndexArray'
+              attributes:
+                type: array
+                items:
+                  $ref: '#/definitions/AttributeValues'
           examples:
             application/json:
               {
-                "data": {
                   "entityId": "Kitchen1",
                   "index": ["2018-01-05T15:44:34", "2018-01-06T15:44:59",
                             "2018-01-07T15:44:59"],
@@ -826,7 +810,6 @@ paths:
                       "values": [1.01, 0.9, 1.02]
                     }
                   ]
-                }
               }
         404:
           description: "Not Found"
@@ -917,19 +900,15 @@ paths:
           schema:
             type: object
             properties:
-              data:
-                type: object
-                properties:
-                  index:
-                    $ref: '#/definitions/IndexArray'
-                  values:
-                    type: array
-                    items:
-                      $ref: '#/definitions/AttributeValues'
+              index:
+                $ref: '#/definitions/IndexArray'
+              values:
+                type: array
+                items:
+                  $ref: '#/definitions/AttributeValues'
           examples:
             application/json:
               {
-                "data": {
                   "index": ["2018-01-05T15:44:34", "2018-01-06T15:44:59",
                             "2018-01-07T15:44:59"],
                   "values": [
@@ -942,7 +921,6 @@ paths:
                       "values": [1.01, 0.9, 1.02]
                     }
                   ]
-                }
               }
         404:
           description: "Not Found"
@@ -999,22 +977,18 @@ paths:
           schema:
             type: object
             properties:
-              data:
-                type: object
-                properties:
-                  entityType:
-                    type: string
-                  attrName:
-                    type: string
-                  entities:
-                    type: array
-                    items:
-                      $ref: '#/definitions/EntityIndexedValues'
+              entityType:
+                type: string
+              attrName:
+                type: string
+              entities:
+                type: array
+                items:
+                  $ref: '#/definitions/EntityIndexedValues'
           examples:
             # TODO: Maybe for this 'query all' we cloud keep a per-type index.
             application/json:
               {
-                "data": {
                   "entityType": "Room",
                   "attrName": "temperature",
                   "entities": [
@@ -1031,7 +1005,6 @@ paths:
                       "values": [21.01, 20.9, 21.02]
                     }
                   ]
-                }
               }
 
 
@@ -1071,18 +1044,14 @@ paths:
           schema:
             type: object
             properties:
-              data:
-                type: object
-                properties:
-                  entities:
-                    type: array
-                    items:
-                      $ref: '#/definitions/EntityIndexedValues'
+              entities:
+                type: array
+                items:
+                  $ref: '#/definitions/EntityIndexedValues'
           examples:
             # TODO: Maybe for this 'query all' we cloud keep a per-type index.
             application/json:
               {
-                "data": {
                   "values": [
                     {
                       "entityId": "Kitchen1",
@@ -1097,7 +1066,6 @@ paths:
                       "values": [21.01, 20.9, 21.02]
                     }
                   ]
-                }
               }
 
 
@@ -1139,29 +1107,25 @@ paths:
           schema:
             type: object
             properties:
-              data:
-                type: object
-                properties:
-                  entityType:
-                    type: string
-                  entities:
-                    type: array
-                    items:
-                      type: object
-                      properties:
-                        entityId:
-                          type: string
-                        index:
-                          $ref: '#/definitions/IndexArray'
-                        attributes:
-                          type: array
-                          items:
-                            $ref: '#/definitions/AttributeValues'
+              entityType:
+                type: string
+              entities:
+                type: array
+                items:
+                  type: object
+                  properties:
+                    entityId:
+                      type: string
+                    index:
+                      $ref: '#/definitions/IndexArray'
+                    attributes:
+                      type: array
+                      items:
+                        $ref: '#/definitions/AttributeValues'
           examples:
             # TODO: Maybe for this 'query all' we cloud keep a per-type index.
             application/json:
               {
-                "data": {
                   "entityType": "Room",
                   "entities": [
                     {
@@ -1196,7 +1160,6 @@ paths:
                       ]
                     }
                   ]
-                }
               }
     delete:
       operationId: reporter.delete.delete_entities
@@ -1260,29 +1223,25 @@ paths:
           schema:
             type: object
             properties:
-              data:
-                type: object
-                properties:
-                  entityType:
-                    type: string
-                  entities:
-                    type: array
-                    items:
-                      type: object
-                      properties:
-                        entityId:
-                          type: string
-                        index:
-                          $ref: '#/definitions/IndexArray'
-                        attributes:
-                          type: array
-                          items:
-                            $ref: '#/definitions/AttributeValues'
+              entityType:
+                type: string
+              entities:
+                type: array
+                items:
+                  type: object
+                  properties:
+                    entityId:
+                      type: string
+                    index:
+                      $ref: '#/definitions/IndexArray'
+                    attributes:
+                      type: array
+                      items:
+                        $ref: '#/definitions/AttributeValues'
           examples:
             # TODO: Maybe for this 'query all' we cloud keep a per-type index.
             application/json:
               {
-                "data": {
                   "values": [
                     {
                       "entityId": "Room1",
@@ -1316,7 +1275,6 @@ paths:
                       ]
                     }
                   ]
-                }
               }
 
 
@@ -1356,27 +1314,23 @@ paths:
           schema:
             type: object
             properties:
-              data:
-                type: object
-                properties:
-                  attrName:
-                    type: string
-                  types:
-                    type: array
-                    items:
-                      type: object
-                      properties:
-                        entityType:
-                          type: string
-                        entities:
-                          type: array
-                          items:
-                            $ref: '#/definitions/EntityIndexedValues'
+              attrName:
+                type: string
+              types:
+                type: array
+                items:
+                  type: object
+                  properties:
+                    entityType:
+                      type: string
+                    entities:
+                      type: array
+                      items:
+                        $ref: '#/definitions/EntityIndexedValues'
           examples:
             # TODO: Maybe for this 'query all' we cloud keep a per-type index.
             application/json:
               {
-                "data": {
                   "attrName": "temperature",
                   "types": [
                     {
@@ -1418,7 +1372,6 @@ paths:
                       ]
                     }
                   ]
-                }
               }
 
   /attrs/{attrName}/value:
@@ -1461,27 +1414,23 @@ paths:
           schema:
             type: object
             properties:
-              data:
-                type: object
-                properties:
-                  attrName:
-                    type: string
-                  types:
-                    type: array
-                    items:
-                      type: object
-                      properties:
-                        entityType:
-                          type: string
-                        entities:
-                          type: array
-                          items:
-                            $ref: '#/definitions/EntityIndexedValues'
+              attrName:
+                type: string
+              types:
+                type: array
+                items:
+                  type: object
+                  properties:
+                    entityType:
+                      type: string
+                    entities:
+                      type: array
+                      items:
+                        $ref: '#/definitions/EntityIndexedValues'
           examples:
             # TODO: Maybe for this 'query all' we cloud keep a per-type index.
             application/json:
               {
-                "data": {
                   "values": [
                     {
                       "entityType": "Room",
@@ -1522,7 +1471,6 @@ paths:
                       ]
                     }
                   ]
-                }
               }
 
   /attrs:
@@ -1563,32 +1511,28 @@ paths:
           schema:
             type: object
             properties:
-              data:
-                type: object
-                properties:
-                  attrs:
-                    type: array
-                    items:
-                      type: object
-                      properties:
-                        attrName:
-                          type: string
-                        types:
-                          type: array
-                          items:
-                            type: object
-                            properties:
-                              entityType:
-                                type: string
-                              entities:
-                                type: array
-                                items:
-                                  $ref: '#/definitions/EntityIndexedValues'
+              attrs:
+                type: array
+                items:
+                  type: object
+                  properties:
+                    attrName:
+                      type: string
+                    types:
+                      type: array
+                      items:
+                        type: object
+                        properties:
+                          entityType:
+                            type: string
+                          entities:
+                            type: array
+                            items:
+                              $ref: '#/definitions/EntityIndexedValues'
           examples:
             # TODO: Maybe for this 'query all' we cloud keep a per-type index.
             application/json:
               {
-                "data": {
                   "attrs:": [
                     {
                       "attrName": "temperature",
@@ -1634,7 +1578,6 @@ paths:
                       ]
                     }
                   ]
-                }
               }
 
 
@@ -1676,32 +1619,28 @@ paths:
           schema:
             type: object
             properties:
-              data:
-                type: object
-                properties:
-                  values:
-                    type: array
-                    items:
-                      type: object
-                      properties:
-                        attrName:
-                          type: string
-                        types:
-                          type: array
-                          items:
-                            type: object
-                            properties:
-                              entityType:
-                                type: string
-                              entities:
-                                type: array
-                                items:
-                                  $ref: '#/definitions/EntityIndexedValues'
+              values:
+                type: array
+                items:
+                  type: object
+                  properties:
+                    attrName:
+                      type: string
+                    types:
+                      type: array
+                      items:
+                        type: object
+                        properties:
+                          entityType:
+                            type: string
+                          entities:
+                            type: array
+                            items:
+                              $ref: '#/definitions/EntityIndexedValues'
           examples:
             # TODO: Maybe for this 'query all' we cloud keep a per-type index.
             application/json:
               {
-                "data": {
                   "values:": [
                     {
                       "attrName": "temperature",
@@ -1747,5 +1686,4 @@ paths:
                       ]
                     }
                   ]
-                }
               }

--- a/src/reporter/query_1T1E1A.py
+++ b/src/reporter/query_1T1E1A.py
@@ -73,12 +73,10 @@ def query_1T1E1A(attr_name,   # In Path
         index = [] if aggr_method and not aggr_period else entities[0]['index']
         matched_attr = lookup_string_match(entities[0], attr_name)
         res = {
-            'data': {
-                'entityId': entities[0]['id'],
-                'attrName': attr_name,
-                'index': index,
-                'values': matched_attr['values'] if matched_attr else []
-            }
+            'entityId': entities[0]['id'],
+            'attrName': attr_name,
+            'index': index,
+            'values': matched_attr['values'] if matched_attr else []
         }
         return res
 
@@ -91,7 +89,7 @@ def query_1T1E1A(attr_name,   # In Path
 
 def query_1T1E1A_value(*args, **kwargs):
     res = query_1T1E1A(*args, **kwargs)
-    if isinstance(res, dict) and 'data' in res:
-        res['data'].pop('entityId')
-        res['data'].pop('attrName')
+    if isinstance(res, dict):
+        res.pop('entityId', None)
+        res.pop('attrName', None)
     return res

--- a/src/reporter/query_1T1ENA.py
+++ b/src/reporter/query_1T1ENA.py
@@ -83,11 +83,9 @@ def query_1T1ENA(entity_id,   # In Path
 
         index = [] if aggr_method and not aggr_period else entities[0]['index']
         res = {
-            'data': {
-                'entityId': entity_id,
-                'index': index,
-                'attributes': attributes
-            }
+            'entityId': entity_id,
+            'index': index,
+            'attributes': attributes
         }
         return res
 
@@ -100,6 +98,6 @@ def query_1T1ENA(entity_id,   # In Path
 
 def query_1T1ENA_value(*args, **kwargs):
     res = query_1T1ENA(*args, **kwargs)
-    if isinstance(res, dict) and 'data' in res:
-        res['data'].pop('entityId')
+    if isinstance(res, dict):
+        res.pop('entityId', None)
     return res

--- a/src/reporter/query_1TNE1A.py
+++ b/src/reporter/query_1TNE1A.py
@@ -134,20 +134,18 @@ def _prepare_response(entities, attr_name, entity_type, entity_ids,
         entries.append(i)
 
     res = {
-        'data': {
-            'entityType': entity_type,
-            'attrName': attr_name,
-            'entities': entries,
-        }
+        'entityType': entity_type,
+        'attrName': attr_name,
+        'entities': entries
     }
     return res
 
 
 def query_1TNE1A_value(*args, **kwargs):
     res = query_1TNE1A(*args, **kwargs)
-    if isinstance(res, dict) and 'data' in res:
-        res['data'].pop('entityType')
-        res['data'].pop('attrName')
-        res['data']['values'] = res['data']['entities']
-        res['data'].pop('entities')
+    if isinstance(res, dict):
+        res.pop('entityType', None)
+        res.pop('attrName', None)
+        res['values'] = res['entities']
+        res.pop('entities', None)
     return res

--- a/src/reporter/tests/geo_queries_fixture.py
+++ b/src/reporter/tests/geo_queries_fixture.py
@@ -60,9 +60,9 @@ def query_1t1e1a(entity_id, query_params, expected_status_code=200):
 
 
 def eids_from_response(response):
-    entities = response.json().get('data', {}).get('entities', {})
+    entities = response.json().get('entities', {})
     if not entities:
-        entities = [response.json().get('data', {})]
+        entities = [response.json()]
 
     return set([e['entityId'] for e in entities])
 

--- a/src/reporter/tests/test_1T1E1A.py
+++ b/src/reporter/tests/test_1T1E1A.py
@@ -34,8 +34,8 @@ def assert_1T1E1A_response(obtained, expected):
     Check API responses for 1T1E1A
     """
     # Assert time index
-    obt_index = obtained['data'].pop('index')
-    exp_index = expected['data'].pop('index')
+    obt_index = obtained.pop('index')
+    exp_index = expected.pop('index')
     assert_equal_time_index_arrays(obt_index, exp_index)
 
     # Assert rest of data
@@ -57,12 +57,10 @@ def test_1T1E1A_defaults(reporter_dataset):
         '1970-01-{:02}T00:00:00.00'.format(i+1) for i in exp_values
     ]
     expected = {
-        'data': {
-            'entityId': entity_id,
-            'attrName': attr_name,
-            'index': exp_index,
-            'values': exp_values,
-        }
+        'entityId': entity_id,
+        'attrName': attr_name,
+        'index': exp_index,
+        'values': exp_values
     }
     assert_1T1E1A_response(obtained, expected)
 
@@ -85,12 +83,10 @@ def test_1T1E1A_aggrMethod(reporter_dataset, aggr_method, aggr_value):
 
     obtained = r.json()
     expected = {
-        'data': {
-            'entityId': entity_id,
-            'attrName': attr_name,
-            'index': [],
-            'values': [aggr_value],
-        }
+        'entityId': entity_id,
+        'attrName': attr_name,
+        'index': [],
+        'values': [aggr_value]
     }
     assert_1T1E1A_response(obtained, expected)
 
@@ -137,12 +133,10 @@ def test_1T1E1A_aggrPeriod(translator, aggr_period, exp_index, ins_period):
     obtained = r.json()
     exp_avg = (0 + 1 + 2 + 3) / 4.
     expected = {
-        'data': {
-            'entityId': entity_id,
-            'attrName': attr_name,
-            'index': exp_index,
-            'values': [exp_avg, exp_avg, exp_avg],
-        }
+        'entityId': entity_id,
+        'attrName': attr_name,
+        'index': exp_index,
+        'values': [exp_avg, exp_avg, exp_avg]
     }
     assert_1T1E1A_response(obtained, expected)
 
@@ -169,12 +163,10 @@ def test_1T1E1A_fromDate_toDate(reporter_dataset):
     # Assert
     obtained = r.json()
     expected = {
-        'data': {
-            'entityId': entity_id,
-            'index': expected_index,
-            'attrName': attr_name,
-            'values': expected_values,
-        }
+        'entityId': entity_id,
+        'index': expected_index,
+        'attrName': attr_name,
+        'values': expected_values
     }
     assert_1T1E1A_response(obtained, expected)
 
@@ -200,12 +192,10 @@ def test_1T1E1A_lastN(reporter_dataset):
     # Assert
     obtained = r.json()
     expected = {
-        'data': {
-            'entityId': entity_id,
-            'attrName': attr_name,
-            'index': expected_index,
-            'values': expected_values,
-        }
+        'entityId': entity_id,
+        'attrName': attr_name,
+        'index': expected_index,
+        'values': expected_values
     }
     assert_1T1E1A_response(obtained, expected)
 
@@ -231,12 +221,10 @@ def test_1T1E1A_limit(reporter_dataset):
     # Assert
     obtained = r.json()
     expected = {
-        'data': {
-            'entityId': entity_id,
-            'attrName': attr_name,
-            'index': expected_index,
-            'values': expected_values,
-        }
+        'entityId': entity_id,
+        'attrName': attr_name,
+        'index': expected_index,
+        'values': expected_values
     }
     assert_1T1E1A_response(obtained, expected)
 
@@ -262,12 +250,10 @@ def test_1T1E1A_offset(reporter_dataset):
     # Assert
     obtained = r.json()
     expected = {
-        'data': {
-            'entityId': entity_id,
-            'attrName': attr_name,
-            'index': expected_index,
-            'values': expected_values,
-        }
+        'entityId': entity_id,
+        'attrName': attr_name,
+        'index': expected_index,
+        'values': expected_values
     }
     assert_1T1E1A_response(obtained, expected)
 
@@ -295,12 +281,10 @@ def test_1T1E1A_combined(reporter_dataset):
     # Assert
     obtained = r.json()
     expected = {
-        'data': {
-            'entityId': entity_id,
-            'attrName': attr_name,
-            'index': expected_index,
-            'values': expected_values,
-        }
+        'entityId': entity_id,
+        'attrName': attr_name,
+        'index': expected_index,
+        'values': expected_values
     }
     assert_1T1E1A_response(obtained, expected)
 
@@ -320,10 +304,8 @@ def test_1T1E1A_values_defaults(reporter_dataset):
         '1970-01-{:02}T00:00:00'.format(i+1) for i in expected_values
     ]
     expected = {
-        'data': {
-            'index': expected_index,
-            'values': expected_values,
-        }
+        'index': expected_index,
+        'values': expected_values
     }
     assert_1T1E1A_response(obtained, expected)
 

--- a/src/reporter/tests/test_1T1ENA.py
+++ b/src/reporter/tests/test_1T1ENA.py
@@ -34,8 +34,8 @@ def assert_1T1ENA_response(obtained, expected):
     Check API responses for 1T1ENA
     """
     # Assert time index
-    obt_index = obtained['data'].pop('index')
-    exp_index = expected['data'].pop('index')
+    obt_index = obtained.pop('index')
+    exp_index = expected.pop('index')
     assert_equal_time_index_arrays(obt_index, exp_index)
 
     # Assert rest of data
@@ -57,20 +57,18 @@ def test_1T1ENA_defaults(reporter_dataset):
         '1970-01-{:02}T00:00:00'.format(i+1) for i in expected_temperatures
     ]
     expected = {
-        'data': {
-            'entityId': entity_id,
-            'index': expected_index,
-            'attributes': [
-                {
-                    'attrName': pressure,
-                    'values': expected_pressures,
-                },
-                {
-                    'attrName': temperature,
-                    'values': expected_temperatures,
-                },
-            ]
-        }
+        'entityId': entity_id,
+        'index': expected_index,
+        'attributes': [
+            {
+                'attrName': pressure,
+                'values': expected_pressures,
+            },
+            {
+                'attrName': temperature,
+                'values': expected_temperatures,
+            }
+        ]
     }
     obtained = r.json()
     assert_1T1ENA_response(obtained, expected)
@@ -103,20 +101,18 @@ def test_1T1ENA_aggrMethod(reporter_dataset, aggr_meth, aggr_press, aggr_temp):
 
     # Assert
     expected = {
-        'data': {
-            'entityId': entity_id,
-            'index': [],
-            'attributes': [
-                {
-                    'attrName': pressure,
-                    'values': [aggr_press],
-                },
-                {
-                    'attrName': temperature,
-                    'values': [aggr_temp],
-                },
-            ]
-        }
+        'entityId': entity_id,
+        'index': [],
+        'attributes': [
+            {
+                'attrName': pressure,
+                'values': [aggr_press],
+            },
+            {
+                'attrName': temperature,
+                'values': [aggr_temp],
+            }
+        ]
     }
     obtained = r.json()
     assert_1T1ENA_response(obtained, expected)
@@ -163,20 +159,18 @@ def test_1T1ENA_aggrPeriod(translator, aggr_period, exp_index, ins_period):
 
     # Assert Results
     expected = {
-        'data': {
-            'entityId': entity_id,
-            'index': exp_index,
-            'attributes': [
-                {
-                    'attrName': pressure,
-                    'values': [20., 20., 20.],
-                },
-                {
-                    'attrName': temperature,
-                    'values': [2., 2., 2.],
-                },
-            ]
-        }
+        'entityId': entity_id,
+        'index': exp_index,
+        'attributes': [
+            {
+                'attrName': pressure,
+                'values': [20., 20., 20.],
+            },
+            {
+                'attrName': temperature,
+                'values': [2., 2., 2.],
+            }
+        ]
     }
     obtained = r.json()
     assert_1T1ENA_response(obtained, expected)
@@ -204,20 +198,18 @@ def test_1T1ENA_fromDate_toDate(reporter_dataset):
 
     # Assert
     expected = {
-        'data': {
-            'entityId': entity_id,
-            'index': expected_index,
-            'attributes': [
-                {
-                    'attrName': pressure,
-                    'values': expected_pressures,
-                },
-                {
-                    'attrName': temperature,
-                    'values': expected_temperatures,
-                },
-            ]
-        }
+        'entityId': entity_id,
+        'index': expected_index,
+        'attributes': [
+            {
+                'attrName': pressure,
+                'values': expected_pressures,
+            },
+            {
+                'attrName': temperature,
+                'values': expected_temperatures,
+            }
+        ]
     }
     obtained = r.json()
     assert_1T1ENA_response(obtained, expected)
@@ -244,20 +236,18 @@ def test_1T1ENA_lastN(reporter_dataset):
 
     # Assert
     expected = {
-        'data': {
-            'entityId': entity_id,
-            'index': expected_index,
-            'attributes': [
-                {
-                    'attrName': pressure,
-                    'values': expected_pressures,
-                },
-                {
-                    'attrName': temperature,
-                    'values': expected_temperatures,
-                },
-            ]
-        }
+        'entityId': entity_id,
+        'index': expected_index,
+        'attributes': [
+            {
+                'attrName': pressure,
+                'values': expected_pressures,
+            },
+            {
+                'attrName': temperature,
+                'values': expected_temperatures,
+            }
+        ]
     }
     obtained = r.json()
     assert_1T1ENA_response(obtained, expected)
@@ -284,20 +274,18 @@ def test_1T1ENA_limit(reporter_dataset):
 
     # Assert
     expected = {
-        'data': {
-            'entityId': entity_id,
-            'index': expected_index,
-            'attributes': [
-                {
-                    'attrName': pressure,
-                    'values': expected_pressures,
-                },
-                {
-                    'attrName': temperature,
-                    'values': expected_temperatures,
-                },
-            ]
-        }
+        'entityId': entity_id,
+        'index': expected_index,
+        'attributes': [
+            {
+                'attrName': pressure,
+                'values': expected_pressures,
+            },
+            {
+                'attrName': temperature,
+                'values': expected_temperatures,
+            }
+        ]
     }
     obtained = r.json()
     assert_1T1ENA_response(obtained, expected)
@@ -324,20 +312,18 @@ def test_1T1ENA_offset(reporter_dataset):
 
     # Assert
     expected = {
-        'data': {
-            'entityId': entity_id,
-            'index': expected_index,
-            'attributes': [
-                {
-                    'attrName': pressure,
-                    'values': expected_pressures,
-                },
-                {
-                    'attrName': temperature,
-                    'values': expected_temperatures,
-                },
-            ]
-        }
+        'entityId': entity_id,
+         'index': expected_index,
+         'attributes': [
+            {
+                'attrName': pressure,
+                'values': expected_pressures,
+            },
+            {
+                'attrName': temperature,
+                'values': expected_temperatures,
+            }
+        ]
     }
     obtained = r.json()
     assert_1T1ENA_response(obtained, expected)
@@ -366,20 +352,18 @@ def test_1T1ENA_combined(reporter_dataset):
 
     # Assert
     expected = {
-        'data': {
-            'entityId': entity_id,
-            'index': expected_index,
-            'attributes': [
-                {
-                    'attrName': pressure,
-                    'values': expected_pressures,
-                },
-                {
-                    'attrName': temperature,
-                    'values': expected_temperatures,
-                },
-            ]
-        }
+        'entityId': entity_id,
+        'index': expected_index,
+        'attributes': [
+            {
+                'attrName': pressure,
+                'values': expected_pressures,
+            },
+            {
+                'attrName': temperature,
+                'values': expected_temperatures,
+            }
+        ]
     }
     obtained = r.json()
     assert_1T1ENA_response(obtained, expected)
@@ -400,19 +384,17 @@ def test_1T1ENA_values_defaults(reporter_dataset):
         '1970-01-{:02}T00:00:00'.format(i+1) for i in expected_temperatures
     ]
     expected = {
-        'data': {
-            'index': expected_index,
-            'attributes': [
-                {
-                    'attrName': pressure,
-                    'values': expected_pressures,
-                },
-                {
-                    'attrName': temperature,
-                    'values': expected_temperatures,
-                },
-            ]
-        }
+        'index': expected_index,
+        'attributes': [
+            {
+                'attrName': pressure,
+                'values': expected_pressures,
+            },
+            {
+                'attrName': temperature,
+                'values': expected_temperatures,
+            }
+        ]
     }
     obtained = r.json()
     assert_1T1ENA_response(obtained, expected)

--- a/src/reporter/tests/test_1TNE1A.py
+++ b/src/reporter/tests/test_1TNE1A.py
@@ -33,13 +33,13 @@ def assert_1TNE1A_response(obtained, expected, values_only=False):
     """
     assert isinstance(obtained, dict)
     if not values_only:
-        assert obtained['data']['entityType'] == entity_type
-        assert obtained['data']['attrName'] == attr_name
-        obt_entities = obtained['data']['entities']
-        exp_entities = expected['data']['entities']
+        assert obtained['entityType'] == entity_type
+        assert obtained['attrName'] == attr_name
+        obt_entities = obtained['entities']
+        exp_entities = expected['entities']
     else:
-        obt_entities = obtained['data']['values']
-        exp_entities = expected['data']['values']
+        obt_entities = obtained['values']
+        exp_entities = expected['values']
 
     for oe, ee in zip(obt_entities, exp_entities):
         obt_index = oe.pop('index')
@@ -80,11 +80,9 @@ def test_1TNE1A_defaults(reporter_dataset):
         }
     ]
     expected = {
-        'data': {
-            'entityType': entity_type,
-            'attrName': attr_name,
-            'entities': expected_entities,
-        }
+        'entityType': entity_type,
+        'attrName': attr_name,
+        'entities': expected_entities
     }
 
     obtained = r.json()
@@ -116,11 +114,9 @@ def test_1TNE1A_one_entity(reporter_dataset):
         }
     ]
     expected = {
-        'data': {
-            'entityType': entity_type,
-            'attrName': attr_name,
-            'entities': expected_entities,
-        }
+        'entityType': entity_type,
+        'attrName': attr_name,
+        'entities': expected_entities
     }
     obtained = r.json()
     assert_1TNE1A_response(obtained, expected)
@@ -155,11 +151,9 @@ def test_1TNE1A_some_entities(reporter_dataset):
     ]
 
     expected = {
-        'data': {
-            'entityType': entity_type,
-            'attrName': attr_name,
-            'entities': expected_entities,
-        }
+        'entityType': entity_type,
+        'attrName': attr_name,
+        'entities': expected_entities
     }
     obtained = r.json()
     assert_1TNE1A_response(obtained, expected)
@@ -194,9 +188,7 @@ def test_1TNE1A_values_defaults(reporter_dataset):
 
     obtained = r.json()
     expected = {
-        'data': {
-            'values': expected_entities,
-        }
+        'values': expected_entities
     }
     assert_1TNE1A_response(obtained, expected, values_only=True)
 
@@ -246,11 +238,9 @@ def test_weird_ids(reporter_dataset):
     ]
 
     expected = {
-        'data': {
-            'entityType': entity_type,
-            'attrName': attr_name,
-            'entities': expected_entities,
-        }
+        'entityType': entity_type,
+        'attrName': attr_name,
+        'entities': expected_entities
     }
     obtained = r.json()
     assert_1TNE1A_response(obtained, expected)
@@ -291,11 +281,9 @@ def test_different_time_indexes(translator):
     ]
 
     expected = {
-        'data': {
-            'entityType': entity_type,
-            'attrName': attr_name,
-            'entities': expected_entities,
-        }
+        'entityType': entity_type,
+        'attrName': attr_name,
+        'entities': expected_entities
     }
     obtained = r.json()
     assert_1TNE1A_response(obtained, expected)
@@ -335,9 +323,9 @@ def test_aggregation_is_per_instance(translator):
 
     obtained_data = r.json()
     assert isinstance(obtained_data, dict)
-    assert obtained_data['data']['entityType'] == t
-    assert obtained_data['data']['attrName'] == attr_name
-    assert obtained_data['data']['entities'] == expected_entities
+    assert obtained_data['entityType'] == t
+    assert obtained_data['attrName'] == attr_name
+    assert obtained_data['entities'] == expected_entities
 
     # Index array in the response is the used fromDate and toDate
     query_params = {
@@ -365,9 +353,9 @@ def test_aggregation_is_per_instance(translator):
     ]
     obtained_data = r.json()
     assert isinstance(obtained_data, dict)
-    assert obtained_data['data']['entityType'] == t
-    assert obtained_data['data']['attrName'] == attr_name
-    assert obtained_data['data']['entities'] == expected_entities
+    assert obtained_data['entityType'] == t
+    assert obtained_data['attrName'] == attr_name
+    assert obtained_data['entities'] == expected_entities
 
 
 @pytest.mark.parametrize("aggr_period, exp_index, ins_period", [
@@ -419,9 +407,9 @@ def test_1T1ENA_aggrPeriod(translator, aggr_period, exp_index, ins_period):
     ]
     obtained_data = r.json()
     assert isinstance(obtained_data, dict)
-    assert obtained_data['data']['entityType'] == entity_type
-    assert obtained_data['data']['attrName'] == attr_name
-    assert obtained_data['data']['entities'] == expected_entities
+    assert obtained_data['entityType'] == entity_type
+    assert obtained_data['attrName'] == attr_name
+    assert obtained_data['entities'] == expected_entities
 
 
 def test_1T1E1A_aggrScope(reporter_dataset):

--- a/src/reporter/tests/test_attribute_name_case.py
+++ b/src/reporter/tests/test_attribute_name_case.py
@@ -60,7 +60,7 @@ def query_1t1e1a(entity_id, attr_name):
     url = "{}/entities/{}/attrs/{}".format(QL_URL, entity_id, escaped_attr_name)
     response = requests.get(url)
     assert response.status_code == 200
-    return response.json().get('data', {})
+    return response.json()
 
 
 def query_1tne1a(attr_name):
@@ -68,7 +68,7 @@ def query_1tne1a(attr_name):
     url = "{}/types/{}/attrs/{}".format(QL_URL, entity_type, escaped_attr_name)
     response = requests.get(url)
     assert response.status_code == 200
-    return response.json().get('data', {})
+    return response.json()
 
 
 def query_1t1ena(entity_id, attr1_name, attr2_name):
@@ -78,7 +78,7 @@ def query_1t1ena(entity_id, attr1_name, attr2_name):
     }
     response = requests.get(url, query_params)
     assert response.status_code == 200
-    return response.json().get('data', {})
+    return response.json()
 
 
 @pytest.mark.parametrize('attr_name', [

--- a/src/reporter/tests/test_entities_with_odd_chars.py
+++ b/src/reporter/tests/test_entities_with_odd_chars.py
@@ -29,7 +29,7 @@ def query_entity(entity_id, attr_name):
     url = "{}/entities/{}/attrs/{}".format(QL_URL, entity_id, escaped_attr_name)
     response = requests.get(url)
     assert response.status_code == 200
-    return response.json().get('data', {})
+    return response.json()
 
 
 def delete_entities(entity_type):

--- a/src/reporter/tests/test_incomplete_entities.py
+++ b/src/reporter/tests/test_incomplete_entities.py
@@ -14,7 +14,7 @@ def get_all_stored_attributes(entity_id):
 
     url = "{}/entities/{}".format(QL_URL, entity_id)
     response = requests.get(url)
-    attrs = response.json().get('data', {}).get('attributes', [])
+    attrs = response.json().get('attributes', [])
 
     attr_values_map = {}
     for a in attrs:
@@ -24,7 +24,6 @@ def get_all_stored_attributes(entity_id):
 # e.g. curl -v http://0.0.0.0:8668/v2/entities/d:1
 # returns
 # {
-#   "data": {
 #     "attributes": [
 #       {
 #         "attrName": "a1",
@@ -49,7 +48,6 @@ def get_all_stored_attributes(entity_id):
 #       "2018-12-20T10:56:38.654",
 #       "2018-12-20T11:46:21.303"
 #     ]
-#   }
 # }
 
 

--- a/src/reporter/tests/test_integration.py
+++ b/src/reporter/tests/test_integration.py
@@ -47,7 +47,7 @@ def test_integration(entity, clean_mongo, clean_crate):
     )
     r = requests.get(query_url, params=query_params)
     assert r.status_code == 200, r.text
-    data = r.json()['data']
+    data = r.json()
     assert len(data['index']) == 4
     assert len(data['attributes']) == 2
     assert data['attributes'][0]['values'] == [720.0, 721.0, 722.0, 723.0]

--- a/src/reporter/tests/test_multitenancy.py
+++ b/src/reporter/tests/test_multitenancy.py
@@ -55,7 +55,7 @@ def test_integration_with_orion(clean_mongo, clean_crate, entity):
     r = requests.get(url, params=query_params, headers=h)
     assert r.status_code == 200, r.text
     obtained = r.json()
-    assert obtained['data']['entityId'] == entity['id']
+    assert obtained['entityId'] == entity['id']
 
     # Query WITHOUT headers
     r = requests.get(url, params=query_params)

--- a/src/reporter/tests/test_time_format.py
+++ b/src/reporter/tests/test_time_format.py
@@ -23,12 +23,10 @@ def check_time_index(input_index, expected_index=None):
 
     # Check Response
     expected = {
-        'data': {
-            'entityId': 'Room0',
-            'attrName': 'temperature',
-            'index': expected_index,
-            'values': [0, 1, 2],
-        }
+        'entityId': 'Room0',
+        'attrName': 'temperature',
+        'index': expected_index,
+        'values': [0, 1, 2]
     }
     assert_1T1E1A_response(obtained, expected)
 

--- a/src/tests/common.py
+++ b/src/tests/common.py
@@ -138,11 +138,11 @@ def check_data(entities):
         assert res.ok, res.text
 
         obtained = res.json()
-        assert obtained['data']['entityId'] == e.id
-        assert obtained['data']['entityId'] == e.id
+        assert obtained['entityId'] == e.id
+        assert obtained['entityId'] == e.id
 
-        index = obtained['data']['index']
-        values = obtained['data']['values']
+        index = obtained['index']
+        values = obtained['values']
         assert len(index) > 1
         assert index[0] != index[-1]
         assert len(index) == len(values)


### PR DESCRIPTION
This PR implements the flattening JSON query responses as outlined in #213 and additionally changes the array type of values returned by the queries from an array of numbers to an array of any type. The reason for the latter change is that attribute values may not only be numbers, but any of the valid types permitted by the NGSI spec.

### Important: Backward compatibility
The implemented changes break API backward compatibility so it will have to be managed accordingly at API and release level---e.g. new API version, advertise change, etc.