### PR TITLE
fix-breaking-travis-ci

### DIFF
--- a/setup_dev_env.sh
+++ b/setup_dev_env.sh
@@ -9,7 +9,7 @@ docker build -t quantumleap .
 
 source deps.env
 
-LH=`( /sbin/ifconfig eth0 | grep 'inet' | cut -d: -f2 | awk '{ print $1}' ) 2> /dev/null`
+LH=`( /sbin/ifconfig ens4 | grep 'inet' | cut -d: -f2 | awk '{ print $1}' ) 2> /dev/null`
 if [ -z "$LH" ]
 then
     # Aliasing so that notifications from orion container reach dev localhost


### PR DESCRIPTION
apparently eth0 is gone in travis ci, thus we need to get the ip from another interface