### PR TITLE
add a query for type ids

### DIFF
--- a/specification/quantumleap.yml
+++ b/specification/quantumleap.yml
@@ -1011,6 +1011,33 @@ paths:
                 "description": "No records were found for such query."
               }
 
+  /v2/types:
+    get:
+      operationId: reporter.reporter.get_types
+      summary: "Get all entity types present in the system"
+      description: "Get an array of distinct entity types present in the system."
+      tags:
+        - queries
+      parameters:
+        # In Query...
+        - $ref: '#/parameters/limit'
+        - $ref: '#/parameters/offset'
+        # In Header...
+        - $ref: '#/parameters/fiware-Service'
+        - $ref: '#/parameters/fiware-ServicePath'
+      responses:
+        200:
+          description: OK
+          schema:
+            type: object
+            properties:
+              types:
+                type: array
+                items:
+                  type: string
+          examples:
+            application/json:
+              { "types": ["Building", "Room", "TemperatureSensor"] }
 
   /v2/types/{entityType}/attrs/{attrName}:
     get:

--- a/src/reporter/reporter.py
+++ b/src/reporter/reporter.py
@@ -40,6 +40,7 @@ from reporter.subscription_builder import build_subscription
 from reporter.timex import select_time_index_value_as_iso, \
     TIME_INDEX_HEADER_NAME
 from geocoding.location import normalize_location
+from typing import Dict, List
 
 
 def log():
@@ -191,6 +192,15 @@ def notify():
     msg = 'Notification successfully processed'
     log().info(msg)
     return msg
+
+
+def get_types(limit: int = 10000, offset: int = 0) -> Dict[str, List[str]]:
+    fiware_s: str = request.headers.get('fiware-service', None)
+    fiware_sp: str = request.headers.get('fiware-servicepath', None) if fiware_s else None
+    with translator_for(fiware_s) as trans:
+        types: List[str] = trans.get_types(limit=limit, offset=offset,
+                                           fiware_service=fiware_s, fiware_servicepath=fiware_sp)
+        return {"types": types}
 
 
 def add_geodata(entity):


### PR DESCRIPTION
This is a proposal for a new endpoint /v2/types, which simply returs the list of distinct entity type ids in the system. It seems that this functionality is not available yet.

There is also a default implementation available in the class BaseTranslator, which is probably not super efficient, but makes it work for all translators that implement query_ids. 

No tests yet, since I couldn't make pytest work on my machine :(