### PR TITLE
Improve crate 4.x support 

### DIFF
--- a/README.md
+++ b/README.md
@@ -41,7 +41,7 @@ QuantumLeap supports both Crate DB and Timescale as time-series DB
 backends but please bear in mind that at the moment we only support
 the following versions:
 
-* Crate backend: Crate DB version `3.3.*` and `4.*` (experimental)
+* Crate backend: Crate DB version `3.3.*` (will be deprecated from QL `0.8` version) and `4.*`
 * Timescale backend: Postgres version `10.*` or `11.*` +
   Timescale extension `1.3.*` + Postgis extension `2.5.*`.
 

--- a/src/translators/crate.py
+++ b/src/translators/crate.py
@@ -22,6 +22,7 @@ NGSI_TO_SQL = {
     "Boolean": 'boolean',
     # TODO since CRATEDB 4.0 timestamp is deprecated,
     # when moving to release 0.8, we will deprecate support for CRATE 3.x
+    # https://crate.io/docs/crate/reference/en/4.2/appendices/release-notes/4.0.0.html#general
     NGSI_ISO8601: 'timestamp',
     NGSI_DATETIME: 'timestamp',
     "Integer": 'long',
@@ -68,6 +69,9 @@ class CrateTranslator(sql_translator.SQLTranslator):
             NGSI_TO_SQL[NGSI_ISO8601] = 'timestamptz'
             NGSI_TO_SQL[NGSI_DATETIME] = 'timestamptz'
             NGSI_TO_SQL[TIME_INDEX] = 'timestamptz'
+            NGSI_TO_SQL["Integer"] = 'bigint'
+            NGSI_TO_SQL["Number"] = 'real'
+            NGSI_TO_SQL[NGSI_TEXT] = 'text'
 
 
     def dispose(self):

--- a/src/translators/crate.py
+++ b/src/translators/crate.py
@@ -20,8 +20,8 @@ CRATE_ARRAY_STR = 'array(string)'
 NGSI_TO_SQL = {
     "Array": CRATE_ARRAY_STR,  # TODO #36: Support numeric arrays
     "Boolean": 'boolean',
-# TODO since CRATEDB 4.0 timestamp is deprecated. Should be replaced with timestampz
-# This means that to maintain both version, we will need a different mechanism
+    # TODO since CRATEDB 4.0 timestamp is deprecated,
+    # when moving to release 0.8, we will deprecate support for CRATE 3.x
     NGSI_ISO8601: 'timestamp',
     NGSI_DATETIME: 'timestamp',
     "Integer": 'long',
@@ -58,6 +58,16 @@ class CrateTranslator(sql_translator.SQLTranslator):
         # we need to think if we want to cache this information
         # and save few msec for evey API call
         self.db_version = self.get_db_version()
+
+        major = int(self.db_version.split('.')[0])
+        if major <= 2:
+            logging.warning("CRATE 2.x support is deprecated")
+        elif major <= 3:
+            logging.warning("CRATE 3.x will be deprecated in release 0.8")
+        elif major >= 4:
+            NGSI_TO_SQL[NGSI_ISO8601] = 'timestamptz'
+            NGSI_TO_SQL[NGSI_DATETIME] = 'timestamptz'
+            NGSI_TO_SQL[TIME_INDEX] = 'timestamptz'
 
 
     def dispose(self):


### PR DESCRIPTION
Since cratedb 4.0 timestamp is deprecated and may be removed any time soon. This update, provide timestamptz support for cratedb >= 4.0