### PR TITLE
fix date format to be compatible also with crate 3.x (#353)

### DIFF
--- a/src/translators/sql_translator.py
+++ b/src/translators/sql_translator.py
@@ -536,7 +536,7 @@ class SQLTranslator(base_translator.BaseTranslator):
             # Match prefix of fiware service path
             if fiware_sp == '/':
                 clauses.append(
-                    " " + FIWARE_SERVICEPATH + " ~* '($|/.*)'")
+                    " " + FIWARE_SERVICEPATH + " ~* '/.*'")
             else:
                 clauses.append(
                     " " + FIWARE_SERVICEPATH + " ~* '"

--- a/src/translators/sql_translator.py
+++ b/src/translators/sql_translator.py
@@ -539,7 +539,8 @@ class SQLTranslator(base_translator.BaseTranslator):
                     " " + FIWARE_SERVICEPATH + " ~* '($|/.*)'")
             else:
                 clauses.append(
-                    " " + FIWARE_SERVICEPATH + " ~* '" + fiware_sp + "($|/.*)'")
+                    " " + FIWARE_SERVICEPATH + " ~* '"
+                    + fiware_sp + "($|/.*)'")
         else:
             # Match prefix of fiware service path
             clauses.append(" " + FIWARE_SERVICEPATH + " = ''")
@@ -811,8 +812,8 @@ class SQLTranslator(base_translator.BaseTranslator):
             try:
                 self.cursor.execute(op)
             except Exception as e:
-                #TODO due to this except in case of sql errors,
-                #all goes fine, and users gets 404 as result
+                # TODO due to this except in case of sql errors,
+                # all goes fine, and users gets 404 as result
                 # Reason 1: fiware_service_path column in legacy dbs.
                 logging.error("{}".format(e))
                 entities = []


### PR DESCRIPTION
#353 reported `fromDate` and `toDate` to not be working correctly. test we run using crate 4.x didn't expose the problem. still user reported the issue, so we looked into using crate 3.x (that will be deprecated in 0.8!) and have been able to reproduce the issue. while the generated timestamp (without `T`) was supported by crate 4.x, it is not the case for 3.x. we changed the timestamp to include `T`.

the issue didn't surface because of the related exception is `managed`, this should probably be modified. currently, the error is at least promoted from "debug" to "error" log, but probably the exception should be simply raised and correctly reported to api caller.

on an additional note, it is unclear why the test using old version of crate that we run on each PR didn't break.