### PR TITLE
Adopt FIWARE contribution guidelines

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,0 +1,45 @@
+## Proposed changes
+
+Describe the big picture of your changes here to communicate to the
+maintainers why we should accept this pull request.
+If it fixes a bug or resolves a feature request, be sure to link to
+that issue.
+
+## Types of changes
+
+What types of changes does your code introduce to the project: _Put
+an `x` in the boxes that apply_
+
+- [ ] Bugfix (non-breaking change which fixes an issue)
+- [ ] New feature (non-breaking change which adds functionality)
+- [ ] Breaking change (fix or feature that would cause existing
+      functionality to not work as expected)
+
+## Checklist
+
+_Put an `x` in the boxes that apply. You can also fill these out after
+creating the PR. If you're unsure about any of them, don't hesitate to
+ask. We're here to help! This is simply a reminder of what we are going
+to look for before merging your code._
+
+- [ ] I have read the [CONTRIBUTING][contrib] doc
+- [ ] I have signed the [CLA][cla]
+- [ ] I have added tests that prove my fix is effective or that my
+      feature works
+- [ ] I have added necessary documentation (if appropriate)
+- [ ] Any dependent changes have been merged and published in
+      downstream modules
+
+## Further comments
+
+If this is a relatively large or complex change, kick off the discussion
+by explaining why you chose the solution you did and what alternatives
+you considered, etc...
+
+
+
+
+[cla]: https://fiware.github.io/contribution-requirements/individual-cla.pdf
+    "FIWARE Individual Contributor License Agreement"
+[contrib]: https://github.com/smartsdk/ngsi-timeseries-api/blob/master/CONTRIBUTING.md
+    "Contributing to QuantumLeap"

--- a/.github/workflows/cla.yml
+++ b/.github/workflows/cla.yml
@@ -21,7 +21,7 @@ jobs:
           path-to-signatures: 'signatures/version1/cla.json'
           path-to-document: 'https://fiware.github.io/contribution-requirements/individual-cla.pdf' # e.g. a CLA or a DCO document
           # branch should not be protected
-          branch: 'master'
+          branch: 'cla-signature'
           allowlist: user1,bot*
           use-dco-flag: false #'Set this to true if you want to use a dco instead of a cla'
 

--- a/.github/workflows/cla.yml
+++ b/.github/workflows/cla.yml
@@ -1,0 +1,34 @@
+name: "CLA Assistant"
+on:
+  issue_comment:
+    types: [created]
+  pull_request_target:
+    types: [opened,closed,synchronize]
+
+jobs:
+  CLAssistant:
+    runs-on: ubuntu-latest
+    steps:
+      - name: "CLA Assistant"
+        if: (github.event.comment.body == 'recheck' || github.event.comment.body == 'I have read the CLA Document and I hereby sign the CLA') || github.event_name == 'pull_request_target'
+        # Alpha Release
+        uses: cla-assistant/github-action@v2.0.1-alpha
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          # the below token should have repo scope and must be manually added by you in the repository's secret
+          PERSONAL_ACCESS_TOKEN : ${{ secrets.PERSONAL_ACCESS_TOKEN }}
+        with:
+          path-to-signatures: 'signatures/version1/cla.json'
+          path-to-document: 'https://fiware.github.io/contribution-requirements/individual-cla.pdf' # e.g. a CLA or a DCO document
+          # branch should not be protected
+          branch: 'master'
+          allowlist: user1,bot*
+          use-dco-flag: false #'Set this to true if you want to use a dco instead of a cla'
+
+         #below are the optional inputs - If the optional inputs are not given, then default values will be taken
+          #remote-organization-name: enter the remote organization name where the signatures should be stored (Default is storing the signatures in the same repository)
+          #remote-repository-name:  enter the  remote repository name where the signatures should be stored (Default is storing the signatures in the same repository)
+          #create-file-commit-message: 'For example: Creating file for storing CLA Signatures'
+          #signed-commit-message: 'For example: $contributorName has signed the CLA in #$pullRequestNo'
+          #custom-notsigned-prcomment: 'pull request comment with Introductory message to ask new contributors to sign'
+          #custom-allsigned-prcomment: 'pull request comment when all contributors has signed, defaults to **CLA Assistant Lite bot** All Contributors have signed the CLA.'

--- a/CODE_OF_CONDUCT.md
+++ b/CODE_OF_CONDUCT.md
@@ -1,76 +1,129 @@
+
 # Contributor Covenant Code of Conduct
 
 ## Our Pledge
 
-In the interest of fostering an open and welcoming environment, we as
-contributors and maintainers pledge to making participation in our project and
-our community a harassment-free experience for everyone, regardless of age, body
-size, disability, ethnicity, sex characteristics, gender identity and expression,
-level of experience, education, socio-economic status, nationality, personal
-appearance, race, religion, or sexual identity and orientation.
+We as members, contributors, and leaders pledge to make participation in our
+community a harassment-free experience for everyone, regardless of age, body
+size, visible or invisible disability, ethnicity, sex characteristics, gender
+identity and expression, level of experience, education, socio-economic status,
+nationality, personal appearance, race, religion, or sexual identity
+and orientation.
+
+We pledge to act and interact in ways that contribute to an open, welcoming,
+diverse, inclusive, and healthy community.
 
 ## Our Standards
 
-Examples of behavior that contributes to creating a positive environment
-include:
+Examples of behavior that contributes to a positive environment for our
+community include:
 
-* Using welcoming and inclusive language
-* Being respectful of differing viewpoints and experiences
-* Gracefully accepting constructive criticism
-* Focusing on what is best for the community
-* Showing empathy towards other community members
+* Demonstrating empathy and kindness toward other people
+* Being respectful of differing opinions, viewpoints, and experiences
+* Giving and gracefully accepting constructive feedback
+* Accepting responsibility and apologizing to those affected by our mistakes,
+  and learning from the experience
+* Focusing on what is best not just for us as individuals, but for the
+  overall community
 
-Examples of unacceptable behavior by participants include:
+Examples of unacceptable behavior include:
 
-* The use of sexualized language or imagery and unwelcome sexual attention or
- advances
-* Trolling, insulting/derogatory comments, and personal or political attacks
+* The use of sexualized language or imagery, and sexual attention or
+  advances of any kind
+* Trolling, insulting or derogatory comments, and personal or political attacks
 * Public or private harassment
-* Publishing others' private information, such as a physical or electronic
- address, without explicit permission
+* Publishing others' private information, such as a physical or email
+  address, without their explicit permission
 * Other conduct which could reasonably be considered inappropriate in a
- professional setting
+  professional setting
 
-## Our Responsibilities
+## Enforcement Responsibilities
 
-Project maintainers are responsible for clarifying the standards of acceptable
-behavior and are expected to take appropriate and fair corrective action in
-response to any instances of unacceptable behavior.
+Community leaders are responsible for clarifying and enforcing our standards of
+acceptable behavior and will take appropriate and fair corrective action in
+response to any behavior that they deem inappropriate, threatening, offensive,
+or harmful.
 
-Project maintainers have the right and responsibility to remove, edit, or
-reject comments, commits, code, wiki edits, issues, and other contributions
-that are not aligned to this Code of Conduct, or to ban temporarily or
-permanently any contributor for other behaviors that they deem inappropriate,
-threatening, offensive, or harmful.
+Community leaders have the right and responsibility to remove, edit, or reject
+comments, commits, code, wiki edits, issues, and other contributions that are
+not aligned to this Code of Conduct, and will communicate reasons for moderation
+decisions when appropriate.
 
 ## Scope
 
-This Code of Conduct applies both within project spaces and in public spaces
-when an individual is representing the project or its community. Examples of
-representing a project or community include using an official project e-mail
-address, posting via an official social media account, or acting as an appointed
-representative at an online or offline event. Representation of a project may be
-further defined and clarified by project maintainers.
+This Code of Conduct applies within all community spaces, and also applies when
+an individual is officially representing the community in public spaces.
+Examples of representing our community include using an official e-mail address,
+posting via an official social media account, or acting as an appointed
+representative at an online or offline event.
 
 ## Enforcement
 
 Instances of abusive, harassing, or otherwise unacceptable behavior may be
-reported by contacting the project team at info@martel-innovate.com. All
-complaints will be reviewed and investigated and will result in a response that
-is deemed necessary and appropriate to the circumstances. The project team is
-obligated to maintain confidentiality with regard to the reporter of an incident.
-Further details of specific enforcement policies may be posted separately.
+reported to the community leaders responsible for enforcement at
+[INSERT CONTACT METHOD].
+All complaints will be reviewed and investigated promptly and fairly.
 
-Project maintainers who do not follow or enforce the Code of Conduct in good
-faith may face temporary or permanent repercussions as determined by other
-members of the project's leadership.
+All community leaders are obligated to respect the privacy and security of the
+reporter of any incident.
+
+## Enforcement Guidelines
+
+Community leaders will follow these Community Impact Guidelines in determining
+the consequences for any action they deem in violation of this Code of Conduct:
+
+### 1. Correction
+
+**Community Impact**: Use of inappropriate language or other behavior deemed
+unprofessional or unwelcome in the community.
+
+**Consequence**: A private, written warning from community leaders, providing
+clarity around the nature of the violation and an explanation of why the
+behavior was inappropriate. A public apology may be requested.
+
+### 2. Warning
+
+**Community Impact**: A violation through a single incident or series
+of actions.
+
+**Consequence**: A warning with consequences for continued behavior. No
+interaction with the people involved, including unsolicited interaction with
+those enforcing the Code of Conduct, for a specified period of time. This
+includes avoiding interactions in community spaces as well as external channels
+like social media. Violating these terms may lead to a temporary or
+permanent ban.
+
+### 3. Temporary Ban
+
+**Community Impact**: A serious violation of community standards, including
+sustained inappropriate behavior.
+
+**Consequence**: A temporary ban from any sort of interaction or public
+communication with the community for a specified period of time. No public or
+private interaction with the people involved, including unsolicited interaction
+with those enforcing the Code of Conduct, is allowed during this period.
+Violating these terms may lead to a permanent ban.
+
+### 4. Permanent Ban
+
+**Community Impact**: Demonstrating a pattern of violation of community
+standards, including sustained inappropriate behavior,  harassment of an
+individual, or aggression toward or disparagement of classes of individuals.
+
+**Consequence**: A permanent ban from any sort of public interaction within
+the community.
 
 ## Attribution
 
-This Code of Conduct is adapted from the [Contributor Covenant][homepage], version 1.4,
-available at https://www.contributor-covenant.org/version/1/4/code-of-conduct.html
+This Code of Conduct is adapted from the [Contributor Covenant][homepage],
+version 2.0, available at
+https://www.contributor-covenant.org/version/2/0/code_of_conduct.html.
+
+Community Impact Guidelines were inspired by [Mozilla's code of conduct
+enforcement ladder](https://github.com/mozilla/diversity).
 
 [homepage]: https://www.contributor-covenant.org
 
-For answers to common questions about this code of conduct, see
-https://www.contributor-covenant.org/faq
+For answers to common questions about this code of conduct, see the FAQ at
+https://www.contributor-covenant.org/faq. Translations are available at
+https://www.contributor-covenant.org/translations.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,68 @@
+# Contributing to QuantumLeap
+
+Thanks for checking out the QuantumLeap Project. We're excited to hear
+and learn from you. We've put together the following guidelines to help
+you figure out where you can best be helpful.
+
+
+### Ground rules & expectations
+
+Before we get started, here are a few things we expect from you (and
+that you should expect from others):
+
+- Be kind and thoughtful in your conversations around this project.
+  We all come from different backgrounds and projects, which means we
+  likely have different perspectives on "how open source is done."
+  Try to listen to others rather than convince them that your way is
+  correct.
+- This project is released with a [Contributor Code of Conduct][conduct].
+  By participating in this project, you agree to abide by its terms.
+- If you open a pull request, you must sign the [Individual Contributor
+  License Agreement][cla] by stating in a comment _"I have read the CLA
+  Document and I hereby sign the CLA"_
+- Please ensure that your contribution passes all tests. If there are
+  test failures, you will need to address them before we can merge your
+  contribution.
+- When adding content, please consider if it is widely valuable. Please
+  don't add references or links to things you or your employer have
+  created as others will do so if they appreciate it.
+
+
+### How to contribute
+
+If you'd like to contribute, start by searching through the [issues][gi]
+and [pull requests][pr] to see whether someone else has raised a similar
+idea or question.
+
+If you don't see your idea listed, and you think it fits into the goals
+of this guide, do one of the following:
+
+- **If your contribution is minor,** such as a typo fix, open a pull
+  request.
+- **If your contribution is major,** such as a new guide, start by
+  opening an issue first. That way, other people can weigh in on the
+  discussion before you do any work.
+
+
+### Community
+
+Discussions about the Open Source Guides take place on this repository's
+[Issues][gi] and [Pull Requests][pr] sections. Anybody is welcome to join
+these conversations.
+
+Wherever possible, do not take these conversations to private channels,
+including contacting the maintainers directly.
+Keeping communication public means everybody can benefit and learn from
+the conversation.
+
+
+
+
+[cla]: https://fiware.github.io/contribution-requirements/individual-cla.pdf
+    "FIWARE Individual Contributor License Agreement"
+[conduct]: ./CODE_OF_CONDUCT.md
+    "Contributor Covenant Code of Conduct"
+[gi]: https://github.com/smartsdk/ngsi-timeseries-api/issues
+    "GitHub Issues"
+[pr]: https://github.com/smartsdk/ngsi-timeseries-api/pulls
+    "GitHub Pull Requests"

--- a/README.md
+++ b/README.md
@@ -65,7 +65,7 @@ section.
 ## Contributing
 
 Refer to the [Contributing](https://quantumleap.readthedocs.io/en/latest/user/contributing/)
-section.
+section and to the [project's contribution guidelines](https://github.com/smartsdk/ngsi-timeseries-api/blob/master/CONTRIBUTING.md).
 
 ## Extra resources
 

--- a/README.md
+++ b/README.md
@@ -65,7 +65,7 @@ section.
 ## Contributing
 
 Refer to the [Contributing](https://quantumleap.readthedocs.io/en/latest/user/contributing/)
-section and to the [project's contribution guidelines](https://github.com/smartsdk/ngsi-timeseries-api/blob/master/CONTRIBUTING.md).
+section and to the [contribution guidelines](./CONTRIBUTING.md).
 
 ## Extra resources
 

--- a/docs/manuals/user/contributing.md
+++ b/docs/manuals/user/contributing.md
@@ -3,7 +3,7 @@
 We welcome contributions and value your ideas. Please use GitHub Issues
 if you would like to suggest ideas, request new features or enhancements,
 or report bugs. To contribute code, open a GitHub Pull Requests. If you
-are new to the project, we kindly ask you to review [QuantumLeap]'s
+are new to the project, we kindly ask you to review QuantumLeap's
 [contribution guidelines][contrib] as well as FIWARE's [contribution
 requirements][fiware-contrib].
 

--- a/docs/manuals/user/contributing.md
+++ b/docs/manuals/user/contributing.md
@@ -1,13 +1,13 @@
 ## Contributions
 
-Contributions are more than welcome in the form of pull requests.
+We welcome contributions and value your ideas. Please use GitHub Issues
+if you would like to suggest ideas, request new features or enhancements,
+or report bugs. To contribute code, open a GitHub Pull Requests. If you
+are new to the project, we kindly ask you to review [QuantumLeap]'s
+[contribution guidelines][contrib] as well as FIWARE's [contribution
+requirements][fiware-contrib].
 
-You can either pick one of the [open issues](https://github.com/smartsdk/ngsi-timeseries-api/issues)
-to work on, or provide enhancements according to your own needs. In any case,
-we suggest getting in touch beforehand to make sure the contribution will be
-aligned with the current development status.
-
-To contribute:
+To contribute code:
 
 1. Fork the repository and clone the fork to your local development environment
 1. Identify a modular contribution to the code (avoid too large contributions
@@ -26,8 +26,6 @@ contributions"
    - Repeat until approval
 1. Done :) You can delete the branch in your repository.
 
-Ultimately, contributing guides should keep aligned with those suggested by
-FIWARE (see [here](https://github.com/Fiware/developmentGuidelines/blob/master/external_contributions.mediawiki)).
 
 ## Development Setup
 
@@ -100,3 +98,11 @@ In the current project tree structure you can find:
         - `translators`: Specific translators for each time-series databases,
         responsible for interacting with the lower-level database details.
         - `utils`: Common shared stuff looking for a better place to live in.
+
+
+
+
+[contrib]: https://github.com/smartsdk/ngsi-timeseries-api/blob/master/CONTRIBUTING.md
+    "Contributing to QuantumLeap"
+[fiware-contrib]: https://github.com/FIWARE/contribution-requirements/
+    "FIWARE Platform Contribution Requirements"


### PR DESCRIPTION
This PR makes QL comply with FiWare tech committee's recent decision about contribution guidelines and CLA---see #389. Specifically we have

* updated the code of conduct (Contributor Covenant Code of Conduct 2.0)
* added a contribution guidelines doc as required by FiWare
* implemented the FiWare PR template
* enforced signing of FiWare CLA on PR submission

Notice the signing of CLA uses a GitHub action that [probably won't work][protect] out of the box for us since our `master` branch is protected. Let's see what happens after the merge, if it actually works then all the better, otherwise we'll have to come up with a workaround.

Also I've added a repo secret called `PERSONAL_ACCESS_TOKEN`---which is what the GitHub action looks for

- https://github.com/smartsdk/ngsi-timeseries-api/pull/390/files#r518955135
- https://github.com/smartsdk/ngsi-timeseries-api/settings/secrets/actions

The secret's value is just a placeholder for now. We'll have to generate a personal access token with a scope of `repo`:

- https://docs.github.com/en/free-pro-team@latest/github/authenticating-to-github/creating-a-personal-access-token

and then set `PERSONAL_ACCESS_TOKEN` to that token. I've tried generating one using my personal GitHub account but I couldn't manage to make it specific to this repo, i.e. I can only generate a token that gives access to all of my repos, including my private ones!



[protect]: https://github.com/smartsdk/ngsi-timeseries-api/pull/390/files#r518942126