### PR TITLE
Fix Docker Hub pull request limit reached in Travis

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -14,6 +14,7 @@ before_script:
   - sudo service postgresql stop
 
 script:
+  - echo "$DOCKER_PASSWORD" | docker login -u "$DOCKER_USERNAME" --password-stdin
   - source setup_dev_env.sh
   - sh run_tests.sh
 


### PR DESCRIPTION
* added DOCKER_PASSWORD and DOCKER_USERNAME to travis
* authenticate before launching CI tests

## Proposed changes

As discussed in https://blog.travis-ci.com/docker-rate-limits, Docker recently announced that they will be actively limiting rates for free and anonymous users in an effort to make Docker, as an organisation, as sustainable as possible.
Due to this, during last CI processes we noticed an increasing number of errors:
**Docker Hub: You have reached your pull rate limit**

## Types of changes

What types of changes does your code introduce to the project: _Put
an `x` in the boxes that apply_

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing
      functionality to not work as expected)

## Checklist

_Put an `x` in the boxes that apply. You can also fill these out after
creating the PR. If you're unsure about any of them, don't hesitate to
ask. We're here to help! This is simply a reminder of what we are going
to look for before merging your code._

- [x] I have read the [CONTRIBUTING][contrib] doc
- [x] I have signed the [CLA][cla]
- [x] I have added tests that prove my fix is effective or that my
      feature works
- [x] I have added necessary documentation (if appropriate)
- [x] Any dependent changes have been merged and published in
      downstream modules

## Further comments

N/A


[cla]: https://fiware.github.io/contribution-requirements/individual-cla.pdf
    "FIWARE Individual Contributor License Agreement"
[contrib]: https://github.com/smartsdk/ngsi-timeseries-api/blob/master/CONTRIBUTING.md
    "Contributing to QuantumLeap"
