### PR TITLE
Release 0.8.0

### DIFF
--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -1,5 +1,61 @@
 # QuantumLeap Release Notes
 
+## 0.8.0
+
+#### New features
+- Experimental NGSI-LD support
+  - Make the notify endpoint accept NGSI-LD payloads, convert them to
+    tabular format and store them in the DB backend (#373)
+  - Retain NGSI-v2 backward compatibility (#373)
+  - Verify basic Orion-LD interoperability (#413)
+- Improved performance
+  - Make CrateDB async writes the default but allow the setting to be
+    overwritten through configuration (#384)
+  - Reduce DB queries on insert through a Redis metadata cache (#373)
+  - Pool DB connections (#373)
+- Expose configuration settings to enable/disable caching of geo-queries
+  and metadata queries on insert (#429)
+- Better logs
+  - Adopt Orion log format and improve log messages (#373)
+  - Log FiWare correlation ID to support tracking of requests from
+    agents (through Orion) to QuantumLeap (#373)
+  - Add process and thread ID to log entries (#367)
+  - Make log messages more descriptive and use debug log level (#355)
+  - Timestamp log entries (#352)
+- Assign NGSI attribute values a DB type according to their JSON type
+  if no NGSI type is present rather than defaulting to text (#373)
+- Make all API endpoints work with Timescale as a backend (#374)
+- Support running QuantumLeap as a WSGI app in Gunicorn (#357)
+- Collect telemetry time-series to analyse performance (#411)
+
+#### Bug fixes
+- Honour default DB backend setting in YAML configuration (#405)
+- Change health status from critical to warning when cache backend
+  is down (#402)
+- Explicitly add new columns to CrateDB tables to cater to corner cases
+  where new columns aren't added if using Crate's dynamic column policy (#373)
+- Log a warning if there's a type mismatch between NGSI and DB date-time
+  rather than making queries crash (#387)
+- Use proper ISO 8601 date-times and FiWare service path match operator
+  in CrateDB queries (#371)
+- Use proper CrateDB types rather than deprecated aliases (#370)
+- Assign entities to their respective service paths when a notification
+  contains multiple service paths (#363, #364, #365)
+- Return HTTP 500 on DB insert failure (#346)
+
+#### Documentation
+- Note delay to be expected between an entity insertion and its subsequent
+  availability for querying (#420)
+- Update Japanese documentation (#414)
+- Substantial updates regarding Redis cache, benchmarks and NGSI-LD
+  support (#373)
+- Gunicorn security settings for QuantumLeap (#380)
+- Mention CrateDB lacks support for 3D coordinates (#340)
+
+#### Technical debt
+- Clean up and refactor translator tests (#403)
+
+
 ## 0.7.6
 
 #### New features

--- a/specification/quantumleap.yml
+++ b/specification/quantumleap.yml
@@ -1,7 +1,7 @@
 swagger: '2.0'  # For 3.0 see (https://github.com/zalando/connexion/issues/420)
 info:
   title: "QuantumLeap API"
-  version: "0.7.6"      # we'll keep it aligned with QL version
+  version: "0.8.0"      # we'll keep it aligned with QL version
 host: "localhost:8668"  # it'll run in the same container, hence localhost.
 produces:
   - text/plain

--- a/src/reporter/tests/test_version.py
+++ b/src/reporter/tests/test_version.py
@@ -6,5 +6,5 @@ def test_version():
     r = requests.get('{}'.format(version_url))
     assert r.status_code == 200, r.text
     assert r.json() == {
-        "version": "0.7.6"
+        "version": "0.8.0"
     }

--- a/src/reporter/version.py
+++ b/src/reporter/version.py
@@ -2,5 +2,5 @@
 
 def version():
     return {
-        'version': '0.7.6'
+        'version': '0.8.0'
     }


### PR DESCRIPTION
With this PR, we releases QuantumLeap version `0.8.0`. This version comes with:

* Experimental support to store NGSI-LD payloads: The `notify` API endpoint now accepts both NGSI-LD and NGSI-v2 entities! While there are still some limitations to what NGSI-LD payloads QuantumLeap can process, the most common scenarios should be covered.
* Much improved data ingestion (`notify` API endpoint) performance with a brand new Redis query cache.
* Full support for Timescale: The Timescale backend is now on par, in terms of features, with the CrateDB backend---i.e. all API endpoints work both with Timescale and CrateDB. Running both backends side-by-side is also supported---e.g. routing data to a specific DB depending on tenant.
* Gunicorn support: You can now run QuantumLeap as a WSGI app in your own Gunicorn server or even start QuantumLeap with its own embedded Gunicorn instance.
* Ability to collect telemetry time-series for performance analysis---turn on telemetry then use e.g. Pandas to analyse your data.
* Better logs and documentation as well as a number of critical bug fixes. 

See below for the details. We recommend QuantumLeap `0.7.6` users to upgrade to this version. 

### New features
- Experimental NGSI-LD support
  - Make the notify endpoint accept NGSI-LD payloads, convert them to tabular format and store them in the DB backend (#373)
  - Retain NGSI-v2 backward compatibility (#373)
  - Verify basic Orion-LD interoperability (#413)
- Improved performance
  - Make CrateDB async writes the default but allow the setting to be overwritten through configuration (#384)
  - Reduce DB queries on insert through a Redis metadata cache (#373)
  - Pool DB connections (#373)
- Expose configuration settings to enable/disable caching of geo-queries and metadata queries on insert (#429)
- Better logs
  - Adopt Orion log format and improve log messages (#373)
  - Log FiWare correlation ID to support tracking of requests from agents (through Orion) to QuantumLeap (#373)
  - Add process and thread ID to log entries (#367)
  - Make log messages more descriptive and use debug log level (#355)
  - Timestamp log entries (#352)
- Assign NGSI attribute values a DB type according to their JSON type if no NGSI type is present rather than defaulting to text (#373)
- Make all API endpoints work with Timescale as a backend (#374)
- Support running QuantumLeap as a WSGI app in Gunicorn (#357)
- Collect telemetry time-series to analyse performance (#411)

### Bug fixes
- Honour default DB backend setting in YAML configuration (#405)
- Change health status from critical to warning when cache backend is down (#402)
- Explicitly add new columns to CrateDB tables to cater to corner cases where new columns aren't added if using Crate's dynamic column policy (#373)
- Log a warning if there's a type mismatch between NGSI and DB date-time rather than making queries crash (#387)
- Use proper ISO 8601 date-times and FiWare service path match operator in CrateDB queries (#371)
- Use proper CrateDB types rather than deprecated aliases (#370)
- Assign entities to their respective service paths when a notification contains multiple service paths (#363, #364, #365)
- Return HTTP 500 on DB insert failure (#346)

### Documentation
- Note delay to be expected between an entity insertion and its subsequent availability for querying (#420)
- Update Japanese documentation (#414)
- Substantial updates regarding Redis cache, benchmarks and NGSI-LD support (#373)
- Gunicorn security settings for QuantumLeap (#380)
- Mention CrateDB lacks support for 3D coordinates (#340)

### Technical debt
- Clean up and refactor translator tests (#403)
